### PR TITLE
Possible bug fix for method overriding for the JL5 Type System.

### DIFF
--- a/src/polyglot/ext/jl5/types/JL5TypeSystem_c.java
+++ b/src/polyglot/ext/jl5/types/JL5TypeSystem_c.java
@@ -1168,12 +1168,7 @@ ParamTypeSystem_c<TypeVariable, ReferenceType> implements JL5TypeSystem {
     @Override
     public boolean areOverrideEquivalent(JL5ProcedureInstance mi, 
         JL5ProcedureInstance mj) {
-      //if (mj.flags().isPublic() || 
-       //   mj.flags().isProtected() ||
-        //  isAccessible(mj, mi.container(), mi.container(), false)) {
         return isSubSignature(mi, mj) || isSubSignature(mj, mi); 
-      //}                                                                                    
-      //return false;                                                                      
     }   
 
     @Override
@@ -1206,48 +1201,8 @@ ParamTypeSystem_c<TypeVariable, ReferenceType> implements JL5TypeSystem {
         else {
             throw new InternalCompilerError("Unexpected return type: " + ri);
         }
-    }
-
-    /*
-    @Override
-    public MethodInstance findImplementingMethod(ClassType ct, MethodInstance mi) {
-        ReferenceType curr = ct;
-        while (curr != null) {
-            List<? extends MethodInstance> possible =
-                    curr.methodsNamed(mi.name());
-            for (MethodInstance mj : possible) {
-                if (!mj.flags().isAbstract()
-                        && (isAccessible(mi, ct) && isAccessible(mj, ct) || isAccessible(mi,
-                                                                                         mj.container()
-                                                                                           .toClass()))) {
-                    // The method mj may be a suitable implementation of mi.
-                    // mj is not abstract, and either mj's container
-                    // can access mi (thus mj can really override mi), or
-                    // mi and mj are both accessible from ct (e.g.,
-                    // mi is declared in an interface that ct implements,
-                    // and mj is defined in a superclass of ct).
-                    if (areOverrideEquivalent((JL5MethodInstance) mi,
-                                              (JL5MethodInstance) mj)) {
-                        return mj;
-                    }
-                }
-            }
-            if (curr == mi.container()) {
-                // we've reached the definition of the abstract
-                // method. We don't want to look higher in the
-                // hierarchy; this is not an optimization, but is
-                // required for correctness.
-                break;
-            }
-
-            curr =
-                    curr.superType() == null ? null : curr.superType()
-                            .toReference();
-        }
-        return null;
-    }
-    */
-
+    } 
+    
     @Override
     public MethodInstance findImplementingMethod(ClassType ct, MethodInstance mi) {
         ReferenceType curr = ct;

--- a/src/polyglot/ext/jl5/types/JL5TypeSystem_c.java
+++ b/src/polyglot/ext/jl5/types/JL5TypeSystem_c.java
@@ -1166,10 +1166,15 @@ ParamTypeSystem_c<TypeVariable, ReferenceType> implements JL5TypeSystem {
     }
 
     @Override
-    public boolean areOverrideEquivalent(JL5ProcedureInstance mi,
-            JL5ProcedureInstance mj) {
-        return isSubSignature(mi, mj) || isSubSignature(mj, mi);
-    }
+    public boolean areOverrideEquivalent(JL5ProcedureInstance mi, 
+        JL5ProcedureInstance mj) {
+      //if (mj.flags().isPublic() || 
+       //   mj.flags().isProtected() ||
+        //  isAccessible(mj, mi.container(), mi.container(), false)) {
+        return isSubSignature(mi, mj) || isSubSignature(mj, mi); 
+      //}                                                                                    
+      //return false;                                                                      
+    }   
 
     @Override
     public boolean isUncheckedConversion(Type fromType, Type toType) {
@@ -1203,6 +1208,7 @@ ParamTypeSystem_c<TypeVariable, ReferenceType> implements JL5TypeSystem {
         }
     }
 
+    /*
     @Override
     public MethodInstance findImplementingMethod(ClassType ct, MethodInstance mi) {
         ReferenceType curr = ct;
@@ -1237,6 +1243,45 @@ ParamTypeSystem_c<TypeVariable, ReferenceType> implements JL5TypeSystem {
             curr =
                     curr.superType() == null ? null : curr.superType()
                             .toReference();
+        }
+        return null;
+    }
+    */
+
+    @Override
+    public MethodInstance findImplementingMethod(ClassType ct, MethodInstance mi) {
+        ReferenceType curr = ct;
+        while (curr != null) {
+            List<? extends MethodInstance> possible =
+                    curr.methodsNamed(mi.name());
+            for (MethodInstance mj : possible) {
+                if (!mj.flags().isAbstract() && 
+                      (mi.flags().isPublic() || 
+                       mi.flags().isProtected() || 
+                       isAccessible(mi, mj.container().toClass()))) {
+                    // The method mj may be a suitable implementation of mi.
+                    // mj is not abstract, and either mj's container 
+                    // can access mi (thus mj can really override mi), or
+                    // mi and mj are both accessible from ct (e.g.,
+                    // mi is declared in an interface that ct implements,
+                    // and mj is defined in a superclass of ct).
+                    if (this.areOverrideEquivalent((JL5MethodInstance) mi,
+                                                   (JL5MethodInstance) mj)) {
+                        return mj;
+                    }
+                }
+            }
+            if (curr == mi.container()) {
+                // we've reached the definition of the abstract 
+                // method. We don't want to look higher in the 
+                // hierarchy; this is not an optimization, but is 
+                // required for correctness. 
+                break;
+            }
+
+            curr =
+                    curr.superType() == null ? null : curr.superType()
+                                                          .toReference();
         }
         return null;
     }


### PR DESCRIPTION
- I had a discussion with Chin about this bug and it looks like the JL5 extension is missing a fix, and the fix for the base JL extension gets override via JL5TypeSystem_c.findImplementingMethod. If anyone has any input whether or not this is a true fix or I'm just getting lucky that would be great, but it seems to work on the tests in polyglot and on my own tests.

- In JL5TypeSystem_c.findImplementingMethod, the method (mi) that is
  is looking for an implementing method (mj) is checked for any of the
  following conditions
    - mi is public
    - mi is protected
    - mi is accessible from mj's container