### PR TITLE
Fix bug in fix in 6f1f6e7

### DIFF
--- a/src/polyglot/types/ArrayType_c.java
+++ b/src/polyglot/types/ArrayType_c.java
@@ -29,7 +29,6 @@ package polyglot.types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import polyglot.util.CodeWriter;
 import polyglot.util.Position;

--- a/src/polyglot/types/ArrayType_c.java
+++ b/src/polyglot/types/ArrayType_c.java
@@ -13,12 +13,12 @@
  * This program and the accompanying materials are made available under
  * the terms of the Lesser GNU Public License v2.0 which accompanies this
  * distribution.
- * 
+ *
  * The development of the Polyglot project has been supported by a
  * number of funding sources, including DARPA Contract F30602-99-1-0533,
  * monitored by USAF Rome Laboratory, ONR Grants N00014-01-1-0968 and
  * N00014-09-1-0652, NSF Grants CNS-0208642, CNS-0430161, CCF-0133302,
- * and CCF-1054172, AFRL Contract FA8650-10-C-7022, an Alfred P. Sloan 
+ * and CCF-1054172, AFRL Contract FA8650-10-C-7022, an Alfred P. Sloan
  * Research Fellowship, and an Intel Research Ph.D. Fellowship.
  *
  * See README for contributors.
@@ -29,6 +29,7 @@ package polyglot.types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import polyglot.util.CodeWriter;
 import polyglot.util.Position;
@@ -81,12 +82,11 @@ public class ArrayType_c extends ReferenceType_c implements ArrayType {
     }
 
     protected FieldInstance createLengthFieldInstance() {
-        FieldInstance fi =
-                ts.fieldInstance(position(),
-                                 this,
-                                 ts.Public().Final(),
-                                 ts.Int(),
-                                 "length");
+        FieldInstance fi = ts.fieldInstance(position(),
+                                            this,
+                                            ts.Public().Final(),
+                                            ts.Int(),
+                                            "length");
         fi.setNotConstant();
         return fi;
     }
@@ -116,7 +116,7 @@ public class ArrayType_c extends ReferenceType_c implements ArrayType {
         // container points to n.
         n.methods = null;
         n.fields = null;
-        init();
+        n.init();
 
         return n;
     }


### PR DESCRIPTION
I ran into a bug compiling Jif against the changes made in 6f1f6e7.  It turns out we were (re)initializing the wrong ArrayType node in the affected method.