### PR TITLE
Support Java 11

### DIFF
--- a/src/polyglot/filemanager/ExtFileManager.java
+++ b/src/polyglot/filemanager/ExtFileManager.java
@@ -27,9 +27,11 @@ package polyglot.filemanager;
 
 import static java.io.File.separatorChar;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -131,6 +133,27 @@ public class ExtFileManager
         if (!defaultLocations.equals(default_locations)) {
             default_locations = defaultLocations;
             clearCache();
+        }
+        setupPackageCacheForBuiltinPackages();
+    }
+
+    private static void setupPackageCacheForBuiltinPackages() {
+        File builtinClasspathFile = new File(
+                System.getProperty("java.home") +
+                        separatorChar + "lib" + separatorChar + "classlist");
+        if (builtinClasspathFile.exists()) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(builtinClasspathFile))) {
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) break;
+                    int index = line.indexOf('/');
+                    while (index >= 0) {
+                        String packagePath = line.substring(0, index).replace('/', '.');
+                        packageCache.put(packagePath, true);
+                        index = line.indexOf('/', index + 1);
+                    }
+                }
+            } catch (IOException e) { }
         }
     }
 

--- a/tests/pthScript
+++ b/tests/pthScript
@@ -13,16 +13,16 @@
 #                    |  ( ErrorKind, "RegExp" )
 #                    |  ( "RegExp" )
 #                    |  ( )
-#      ErrorKind    :   one of, or a unique prefix of one of the following 
-#                       strings: "Warning", "Internal Error", "I/O Error", 
+#      ErrorKind    :   one of, or a unique prefix of one of the following
+#                       strings: "Warning", "Internal Error", "I/O Error",
 #                       "Lexical Error", "Syntax Error", "Semantic Error"
 #                       or "Post-compiler Error".
-#      Filename     :   the name of a file. Is interpreted from the 
+#      Filename     :   the name of a file. Is interpreted from the
 #                       directory where pth is run.
 #      LitString    :   a literal string, enclosed in quotes.
-#      RegExp       :   a regular expression, as in java.util.regex; 
+#      RegExp       :   a regular expression, as in java.util.regex;
 #                       is always enclosed in quotes.
-#      CmdLineArgs  :   additional command line args for the Polyglot 
+#      CmdLineArgs  :   additional command line args for the Polyglot
 #                       compiler; is always enclosed in quotes.
 
 # Compile some java classes first
@@ -31,7 +31,7 @@ javac "-d java-out -cp ." {
 	java-src/ClassFile02.java;
 }
 
-polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-source 1.6\"" {
+polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out" {
         AnonymousClass.jl ;
         AnonymousClass02.jl ;
         AnonymousClass03.jl;
@@ -82,20 +82,20 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
         ClassFile01.jl;
         ClassFile02.jl (Semantic, "incompatible return type");
         ClassLit.jl ;
-	CombRule1.jl; 
+	CombRule1.jl;
 	CombRule2.jl (Semantic, "Method.*cannot be called with arguments");
 	CombRule3.jl (Semantic, "Method.*cannot be called with arguments");
         Conditional1.jl ;
 	ConformanceCheck1.jl (Semantic, "cannot override.*attempting to assign weaker access");
 	ConformanceCheck2.jl (Semantic, "cannot override.*throw set.*is not a subset");
-        ConformanceCheck3.jl ;        
+        ConformanceCheck3.jl ;
         ConformanceCheck4.jl ConformanceCheck4a.jl (Semantic, "should be declared abstract");
-        ConformanceCheck5.jl ;        
-        ConformanceCheck6.jl ;         
-        ConformanceCheck7.jl (Semantic, "should be declared abstract");        
-        packA/ConformanceCheck8.jl packB/ConformanceCheck8b.jl (Semantic, "should be declared abstract"); 
-        ConformanceCheck9.jl ;         
-        ConformanceCheck10.jl packA/ConformanceCheck10a.jl packA/ConformanceCheck10b.jl; 
+        ConformanceCheck5.jl ;
+        ConformanceCheck6.jl ;
+        ConformanceCheck7.jl (Semantic, "should be declared abstract");
+        packA/ConformanceCheck8.jl packB/ConformanceCheck8b.jl (Semantic, "should be declared abstract");
+        ConformanceCheck9.jl ;
+        ConformanceCheck10.jl packA/ConformanceCheck10a.jl packA/ConformanceCheck10b.jl;
         packA/ProtectedAccess1.jl packB/ProtectedAccess2.jl (Semantic, "Method.*inaccessible");
         package1/ProtectedTest.jl package2/ProtectedTestBase.jl (Semantic, "Method.*inaccessible");
         package1/InnerClassAccess.jl package1/InnerClassProblem.jl ;
@@ -167,9 +167,9 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
         Init1.jl ; Init2.jl ; Init3.jl ; Init4.jl ; Init5.jl ;
         Init6.jl ;
         Init7.jl ; Init8.jl ; Init9.jl ;
-	Init10.jl; 
-	Init11.jl; 
-	Init12.jl; 
+	Init10.jl;
+	Init11.jl;
+	Init12.jl;
 	Init13.jl;
 	Init14.jl;
 	Init15.jl;
@@ -231,8 +231,8 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
                         (Lexical, "Long literal.*out of range"),
                         (Syntax);
         Local.jl ;
-        LocalClass.jl ; 
-#        LocalClass2.jl ; 
+        LocalClass.jl ;
+#        LocalClass2.jl ;
         LocalClass3.jl ; LocalClass4.jl ;
 	LocalClass5.jl ;
 	LocalClass6.jl (Semantic, "Circular inheritance");
@@ -269,7 +269,7 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
         Package01a.jl Package01b.jl Package01c.jl (Semantic, "imported type .* not canonical");
         Package02.jl (Semantic, "imported type .* not visible");
         Prim.jl ;
-        Prec.jl ; 
+        Prec.jl ;
 	Prec2.jl ;
 	Prec3.jl ;
 	Protection.jl (Semantic, "Cannot declare abstract method with flags static"),
@@ -303,7 +303,7 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
         StaticOps.jl ;
         SuperCall01.jl;
         Switch1.jl ; Switch2.jl ; Switch3.jl ; Switch4.jl ; Switch5.jl ;
-        Switch6.jl ; 
+        Switch6.jl ;
 #        Switch7.jl ;
         Switch08.jl (Semantic, "not assignable");
         Synchronized01.jl (Semantic, "Cannot synchronize");
@@ -339,8 +339,8 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
         BadFinalInit11.jl (Semantic, "Final field .* might already have been initialized");
         BadFinalInit12.jl (Semantic, "Cannot assign a value to final field");
         BadFinalInit14.jl (Semantic, "Cannot assign a value to final field");
-        BadFinalInit15.jl (Semantic, "Final variable .* might already have been initialized"); 
-        BadFinalInit16.jl (Semantic, "Local variable .* may not have been initialized"); 
+        BadFinalInit15.jl (Semantic, "Final variable .* might already have been initialized");
+        BadFinalInit16.jl (Semantic, "Local variable .* may not have been initialized");
         BadFinalInit17.jl (Semantic, "Final field .* might not have been initialized");
         BadFinalInit18.jl (Semantic, "Cannot assign a value to final field");
         BadIncrement1.jl (Semantic, "Operand of .* operator must be a variable");
@@ -367,11 +367,11 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
 	BadMultipleVarDef.jl (Semantic, "Local variable .* multiply defined"),
 			     (Semantic, "Local variable .* multiply defined");
 	BadOverride.jl (Semantic, "cannot override.*attempting to assign weaker access privileges");
-	BadPrim.jl (Semantic, "Method.*cannot be called with arguments"); 
+	BadPrim.jl (Semantic, "Method.*cannot be called with arguments");
 	BadProt.jl (Semantic, "Interface methods must be public");
 	BadReferences.jl (Semantic, "Member.*ambiguous");
 	BadReferences2.jl (Semantic, "Field.*ambiguous");
-	BadStaticContext.jl (Semantic); 
+	BadStaticContext.jl (Semantic);
         BadSwitch1.jl (Semantic, "Case label must be an integral constant");
 	BadSwitch2.jl (Semantic, "Duplicate case label");
 	Constants12.jl (Semantic, "Duplicate case label"),
@@ -384,21 +384,21 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
         CircularInheritance2.jl (Semantic, "Circular inheritance");
         CircularInheritance3.jl (Semantic, "Circular inheritance");
 	Errors.jl (Semantic, "Method.*cannot be called with arguments");
-	Errors2.jl (Semantic, "Could not find type"); 
-	LabeledBreak2.jl (Semantic, "Unreachable statement"); 
+	Errors2.jl (Semantic, "Could not find type");
+	LabeledBreak2.jl (Semantic, "Unreachable statement");
         InitCheckerBug.jl ;
-	NoInit1.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit10.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit11.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit12.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit2.jl (Semantic, "Local variable .* may not have been initialized"); 
+	NoInit1.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit10.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit11.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit12.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit2.jl (Semantic, "Local variable .* may not have been initialized");
 	NoInit3.jl (Semantic, "Unreachable statement");
-	NoInit4.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit5.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit6.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit7.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit8.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit9.jl (Semantic, "Local variable .* may not have been initialized"); 
+	NoInit4.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit5.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit6.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit7.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit8.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit9.jl (Semantic, "Local variable .* may not have been initialized");
 	StaticContext2.jl (Semantic, "Inner classes cannot declare static methods");
 	NoReturn1.jl  (Semantic, "Missing return statement");
 	NoReturn2.jl (Semantic, "Missing return statement");
@@ -427,29 +427,29 @@ polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out -postopts \"-sour
 	DoubleFlags.jl (Syntax), ();
 
         // on the following file, javac produces an error, but we intentionally do not.
-        //  BadFinalInit13.jl (Post); 
+        //  BadFinalInit13.jl (Post);
 
-	BadForwardRef.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef2.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef3.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef04.jl (Semantic, "Illegal forward ref"); 
+	BadForwardRef.jl (Semantic, "Illegal forward ref");
+	BadForwardRef2.jl (Semantic, "Illegal forward ref");
+	BadForwardRef3.jl (Semantic, "Illegal forward ref");
+	BadForwardRef04.jl (Semantic, "Illegal forward ref");
         Continue1.jl (Semantic, "Target.*not found"), (), (), ();
         Continue2.jl (Semantic, "must be a loop"), (), (), ();
-	ForwardRef4.jl (Semantic, "Illegal forward ref"); 
-	ForwardRef5.jl; 
+	ForwardRef4.jl (Semantic, "Illegal forward ref");
+	ForwardRef5.jl;
 	// the following test has exactly 4 errors in it
-	ForwardRef6.jl (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"); 
+	ForwardRef6.jl (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref");
 	DefAssign01.jl (Semantic, "Final field \"x\" might not have been initialized");
 }
 
-polyglot.frontend.JLExtensionInfo "-d out -postopts \"-source 1.6\"" {
+polyglot.frontend.JLExtensionInfo "-d out" {
 	package3/name/ClassPackConflict.jl;
 }
 
-polyglot.frontend.JLExtensionInfo "-d insensTest -cp insensTest -postopts \"-source 1.6\"" {
+polyglot.frontend.JLExtensionInfo "-d insensTest -cp insensTest" {
 	Insens.jl;
 	InsensBug.jl;
 }

--- a/testsjl5/pthScript
+++ b/testsjl5/pthScript
@@ -15,16 +15,16 @@
 #                    |  ( ErrorKind, "RegExp" )
 #                    |  ( "RegExp" )
 #                    |  ( )
-#      ErrorKind    :   one of, or a unique prefix of one of the following 
-#                       strings: "Warning", "Internal Error", "I/O Error", 
+#      ErrorKind    :   one of, or a unique prefix of one of the following
+#                       strings: "Warning", "Internal Error", "I/O Error",
 #                       "Lexical Error", "Syntax Error", "Semantic Error"
 #                       or "Post-compiler Error".
-#      Filename     :   the name of a file. Is interpreted from the 
+#      Filename     :   the name of a file. Is interpreted from the
 #                       directory where pth is run.
 #      LitString    :   a literal string, enclosed in quotes.
-#      RegExp       :   a regular expression, as in java.util.regex; 
+#      RegExp       :   a regular expression, as in java.util.regex;
 #                       is always enclosed in quotes.
-#      CmdLineArgs  :   additional command line args for the Polyglot 
+#      CmdLineArgs  :   additional command line args for the Polyglot
 #                       compiler; is always enclosed in quotes.
 
 # Compile some java classes first
@@ -39,8 +39,8 @@ javac "-d java-out -cp ." {
 	java-src/Call02B.java;
 	java-src/Call02D.java;
 }
- 
-polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-source 1.5 -Xlint\\:-options\" -morepermissiveinference" {
+
+polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \" -Xlint\\:-options\" -morepermissiveinference" {
         Access01.jl5;
         Access02.jl5;
         Access03A.jl5  Access03B.jl5;
@@ -224,7 +224,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
         Generics18.jl5 (Post, "Xlint");
         Generics19.jl5;
         Generics20.jl5 (Semantic);
-        Generics21.jl5 (Semantic); 
+        Generics21.jl5 (Semantic);
         Generics22.jl5 (Semantic);
         Generics23.jl5 (Semantic);
         Generics24.jl5 (Semantic, "Wrong number of type parameters"),
@@ -232,7 +232,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
                        (Semantic, "Cannot instantiate .* because it has no formals");
         Generics25.jl5 (Semantic);
         Generics26.jl5 (Post, "Xlint");
-        Generics27.jl5;        
+        Generics27.jl5;
         Generics28.jl5 (Post, "Xlint");
         Generics29.jl5 (Post, "Xlint");
         Generics30.jl5 (Semantic);
@@ -240,7 +240,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
         Generics32.jl5;
         Generics33.jl5 (Semantic);
         Generics34.jl5;
-        Generics35.jl5 (Semantic); 
+        Generics35.jl5 (Semantic);
         Generics36.jl5;
         Generics37.jl5;
         Generics38.jl5;
@@ -435,24 +435,24 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
         wildcard7a.jl5;
         wildcard8.jl5 (Semantic);
         wildcard9.jl5; # TODO
-        wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"); 
-        wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match"); 
-        wildcard12a.jl5(Semantic); 
-        wildcard12b.jl5(Semantic); 
-        wildcard12c.jl5(Semantic); 
-        wildcard12d.jl5(Semantic); 
-        wildcard12e.jl5; 
-        wildcard13a.jl5 (Semantic); 
-        wildcard13b.jl5 (Semantic); 
-        wildcard13c.jl5 (Semantic); 
-        wildcard13d.jl5; 
-        wildcard14a.jl5 (Semantic); 
-        wildcard14b.jl5 (Semantic); 
-        wildcard14c.jl5 (Semantic); 
-        wildcard14d.jl5 ; 
-        wildcard15.jl5 (Semantic),(Semantic); 
+        wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match");
+        wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match");
+        wildcard12a.jl5(Semantic);
+        wildcard12b.jl5(Semantic);
+        wildcard12c.jl5(Semantic);
+        wildcard12d.jl5(Semantic);
+        wildcard12e.jl5;
+        wildcard13a.jl5 (Semantic);
+        wildcard13b.jl5 (Semantic);
+        wildcard13c.jl5 (Semantic);
+        wildcard13d.jl5;
+        wildcard14a.jl5 (Semantic);
+        wildcard14b.jl5 (Semantic);
+        wildcard14c.jl5 (Semantic);
+        wildcard14d.jl5 ;
+        wildcard15.jl5 (Semantic),(Semantic);
         wildcard16.jl5 (Semantic, "Cannot assign long to");
-        wildcard17.jl5 (Semantic),(Semantic),(Semantic); 
+        wildcard17.jl5 (Semantic),(Semantic),(Semantic);
         wildcard18.jl5 (Semantic);
         wildcard19.jl5 (Semantic, "not a subtype .* bound") , (Semantic);
         wildcard20.jl5 (Semantic, "cannot be called");
@@ -464,7 +464,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
 
 # Now run the tests again removing the Java 5-isms.
 # This one uses 1.4 to suppress the warning about raw classes.
-polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options -source 1.4 -target 1.4\" -morepermissiveinference" {
+polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
         Access01.jl5;
         Access02.jl5;
         Access03A.jl5  Access03B.jl5;
@@ -647,7 +647,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Generics18.jl5;
         Generics19.jl5;
         Generics20.jl5 (Semantic);
-        Generics21.jl5 (Semantic); 
+        Generics21.jl5 (Semantic);
         Generics22.jl5 (Semantic);
         Generics23.jl5 (Semantic);
         Generics24.jl5 (Semantic, "Wrong number of type parameters"),
@@ -655,7 +655,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
                        (Semantic, "Cannot instantiate .* because it has no formals");
         Generics25.jl5 (Semantic);
         Generics26.jl5;
-        Generics27.jl5; 
+        Generics27.jl5;
         Generics28.jl5;
         Generics29.jl5;
         Generics30.jl5 (Semantic);
@@ -701,7 +701,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Inherit01.jl5 (Semantic, "Name clash");
         Inherit02.jl5 (Semantic, "Name clash");
         Inherit03.jl5 (Semantic, "Name clash"), (Semantic, "Name clash");
-        InnerClass01.jl5; 
+        InnerClass01.jl5;
         InnerClass02.jl5;
         InnerClass03.jl5;
         InnerClass04.jl5;
@@ -840,7 +840,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         VarArgs11.jl5 (Semantic, "Method .* cannot be called");
         VerySimple.jl5;
         WildCard01.jl5;
-        WildCard02.jl5 (Semantic, "does not match"); 
+        WildCard02.jl5 (Semantic, "does not match");
         WildCard03.jl5;
         WildCard04.jl5;
         WildCard05.jl5;
@@ -859,24 +859,24 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         wildcard7a.jl5;
         wildcard8.jl5 (Semantic);
         wildcard9.jl5; # TODO
-        wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"); 
-        wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match"); 
-        wildcard12a.jl5(Semantic); 
-        wildcard12b.jl5(Semantic); 
-        wildcard12c.jl5(Semantic); 
-        wildcard12d.jl5(Semantic); 
+        wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match");
+        wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match");
+        wildcard12a.jl5(Semantic);
+        wildcard12b.jl5(Semantic);
+        wildcard12c.jl5(Semantic);
+        wildcard12d.jl5(Semantic);
         wildcard12e.jl5;
-        wildcard13a.jl5 (Semantic); 
-        wildcard13b.jl5 (Semantic); 
-        wildcard13c.jl5 (Semantic); 
-        wildcard13d.jl5; 
-        wildcard14a.jl5 (Semantic); 
-        wildcard14b.jl5 (Semantic); 
-        wildcard14c.jl5 (Semantic); 
-        wildcard14d.jl5 ; 
-        wildcard15.jl5 (Semantic),(Semantic); 
+        wildcard13a.jl5 (Semantic);
+        wildcard13b.jl5 (Semantic);
+        wildcard13c.jl5 (Semantic);
+        wildcard13d.jl5;
+        wildcard14a.jl5 (Semantic);
+        wildcard14b.jl5 (Semantic);
+        wildcard14c.jl5 (Semantic);
+        wildcard14d.jl5 ;
+        wildcard15.jl5 (Semantic),(Semantic);
         wildcard16.jl5 (Semantic, "Cannot assign long to");
-        wildcard17.jl5 (Semantic),(Semantic),(Semantic); 
+        wildcard17.jl5 (Semantic),(Semantic),(Semantic);
         wildcard18.jl5 (Semantic);
         wildcard19.jl5 (Semantic, "not a subtype .* bound") , (Semantic);
         wildcard20.jl5 (Semantic, "cannot be called");
@@ -886,14 +886,14 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         wildcard24.jl5;
 }
 
-polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options -source 1.5\" -morepermissivecasts" {
+polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissivecasts" {
         NumericConversion01.jl5;
         PermissiveCasts01.jl5;
         PermissiveCasts02.jl5 (Semantic, "does not match");
         PermissiveCasts03.jl5 (Semantic, "Cannot cast");
 }
 
-polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options -source 1.4\" -morepermissivecasts" {
+polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissivecasts" {
         NumericConversion01.jl5;
         PermissiveCasts01.jl5;
         PermissiveCasts02.jl5 (Semantic, "does not match");
@@ -901,7 +901,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
 }
 
 # Use source/target 1.5 since we're expecting CovariantReturn to be allowed
-polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -leaveCovariantReturns -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options -source 1.5 -target 1.5\" -morepermissiveinference" {
+polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -leaveCovariantReturns -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
         CovariantRet01.jl5;
         CovariantRet02.jl5;
         CovariantRet03.jl5;

--- a/testsjl5/pthScript-JL
+++ b/testsjl5/pthScript-JL
@@ -4,7 +4,7 @@ javac ["../tests/"] "-d java-out -cp ." {
 	java-src/ClassFile02.java;
 }
 
-polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-out -assert -noserial -postopts \"-source 1.5 -Xlint\\:-options\" -morepermissiveinference" {
+polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
         AnonymousClass.jl ;
         AnonymousClass02.jl ;
         AnonymousClass03.jl;
@@ -48,20 +48,20 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         ClassFile01.jl;
         ClassFile02.jl;
         ClassLit.jl ;
-	CombRule1.jl; 
+	CombRule1.jl;
 	CombRule2.jl (Semantic, "Method.*cannot be called with arguments");
 	CombRule3.jl (Semantic, "Method.*cannot be called with arguments");
         Conditional1.jl ;
 	ConformanceCheck1.jl (Semantic, "cannot override.*attempting to assign weaker access");
 	ConformanceCheck2.jl (Semantic, "cannot override.*throw set.*is not a subset");
-        ConformanceCheck3.jl ;        
+        ConformanceCheck3.jl ;
         ConformanceCheck4.jl ConformanceCheck4a.jl (Semantic, "should be declared abstract");
-        ConformanceCheck5.jl ;        
-        ConformanceCheck6.jl ;         
-        ConformanceCheck7.jl (Semantic, "should be declared abstract");        
-        packA/ConformanceCheck8.jl packB/ConformanceCheck8b.jl (Semantic, "should be declared abstract"); 
-        ConformanceCheck9.jl ;         
-        ConformanceCheck10.jl packA/ConformanceCheck10a.jl packA/ConformanceCheck10b.jl; 
+        ConformanceCheck5.jl ;
+        ConformanceCheck6.jl ;
+        ConformanceCheck7.jl (Semantic, "should be declared abstract");
+        packA/ConformanceCheck8.jl packB/ConformanceCheck8b.jl (Semantic, "should be declared abstract");
+        ConformanceCheck9.jl ;
+        ConformanceCheck10.jl packA/ConformanceCheck10a.jl packA/ConformanceCheck10b.jl;
         packA/ProtectedAccess1.jl packB/ProtectedAccess2.jl (Semantic, "Method.*inaccessible");
         package1/ProtectedTest.jl package2/ProtectedTestBase.jl (Semantic, "Method.*inaccessible");
         package1/InnerClassAccess.jl package1/InnerClassProblem.jl ;
@@ -130,9 +130,9 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         Init1.jl ; Init2.jl ; Init3.jl ; Init4.jl ; Init5.jl ;
         Init6.jl ;
         Init7.jl ; Init8.jl ; Init9.jl ;
-	Init10.jl; 
-	Init11.jl; 
-	Init12.jl; 
+	Init10.jl;
+	Init11.jl;
+	Init12.jl;
 	Init13.jl;
 	Init14.jl;
 	Init15.jl;
@@ -194,8 +194,8 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
                         (Lexical, "Long literal.*out of range"),
                         (Syntax);
         Local.jl ;
-        LocalClass.jl ; 
-#        LocalClass2.jl ; 
+        LocalClass.jl ;
+#        LocalClass2.jl ;
         LocalClass3.jl ; LocalClass4.jl ;
 	LocalClass5.jl ;
 	LocalClass6.jl (Semantic, "Circular inheritance");
@@ -229,7 +229,7 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         Package01a.jl Package01b.jl Package01c.jl (Semantic, "imported type .* not canonical");
         Package02.jl (Semantic, "imported type .* not visible");
         Prim.jl ;
-        Prec.jl ; 
+        Prec.jl ;
 	Prec2.jl ;
 	Prec3.jl ;
 	Protection.jl (Semantic, "Cannot declare abstract method with flags static"),
@@ -258,7 +258,7 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         StaticMethod.jl ;
         StaticOps.jl ;
         Switch1.jl ; Switch2.jl ; Switch3.jl ; Switch4.jl ; Switch5.jl ;
-        Switch6.jl ; 
+        Switch6.jl ;
 #        Switch7.jl ;
         Switch08.jl (Semantic, "not assignable");
         Synchronized01.jl (Semantic, "Cannot synchronize");
@@ -290,8 +290,8 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         BadFinalInit11.jl (Semantic, "Final field .* might already have been initialized");
         BadFinalInit12.jl (Semantic, "Cannot assign a value to final field");
         BadFinalInit14.jl (Semantic, "Cannot assign a value to final field");
-        BadFinalInit15.jl (Semantic, "Final variable .* might already have been initialized"); 
-        BadFinalInit16.jl (Semantic, "Local variable .* may not have been initialized"); 
+        BadFinalInit15.jl (Semantic, "Final variable .* might already have been initialized");
+        BadFinalInit16.jl (Semantic, "Local variable .* may not have been initialized");
         BadFinalInit17.jl (Semantic, "Final field .* might not have been initialized");
         BadIncrement1.jl (Semantic, "Operand of .* operator must be a variable");
         BadIncrement2.jl (Semantic, "Operand of .* operator must be a variable");
@@ -316,11 +316,11 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
 	BadMultipleVarDef.jl (Semantic, "Local variable .* multiply defined"),
 			     (Semantic, "Local variable .* multiply defined");
 	BadOverride.jl (Semantic, "cannot override.*attempting to assign weaker access privileges");
-	BadPrim.jl (Semantic, "Method.*cannot be called with arguments"); 
+	BadPrim.jl (Semantic, "Method.*cannot be called with arguments");
 	BadProt.jl (Semantic, "Interface methods must be public");
 	BadReferences.jl (Semantic, "Member.*ambiguous");
 	BadReferences2.jl (Semantic, "Field.*ambiguous");
-	BadStaticContext.jl (Semantic); 
+	BadStaticContext.jl (Semantic);
         BadSwitch1.jl (Semantic, "Case label must be an integral constant");
 	BadSwitch2.jl (Semantic, "Duplicate case label");
 	Constants12.jl (Semantic, "Duplicate case label"),
@@ -333,21 +333,21 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         CircularInheritance2.jl (Semantic, "Circular inheritance");
         CircularInheritance3.jl (Semantic, "Circular inheritance");
 	Errors.jl (Semantic, "Method.*cannot be called with arguments");
-	Errors2.jl (Semantic, "Class .* not found"); 
-	LabeledBreak2.jl (Semantic, "Unreachable statement"); 
+	Errors2.jl (Semantic, "Class .* not found");
+	LabeledBreak2.jl (Semantic, "Unreachable statement");
         InitCheckerBug.jl ;
-	NoInit1.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit10.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit11.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit12.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit2.jl (Semantic, "Local variable .* may not have been initialized"); 
+	NoInit1.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit10.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit11.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit12.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit2.jl (Semantic, "Local variable .* may not have been initialized");
 	NoInit3.jl (Semantic, "Unreachable statement");
-	NoInit4.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit5.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit6.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit7.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit8.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit9.jl (Semantic, "Local variable .* may not have been initialized"); 
+	NoInit4.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit5.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit6.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit7.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit8.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit9.jl (Semantic, "Local variable .* may not have been initialized");
 	StaticContext2.jl (Semantic, "Inner classes cannot declare static methods");
 	NoReturn1.jl  (Semantic, "Missing return statement");
 	NoReturn2.jl (Semantic, "Missing return statement");
@@ -376,18 +376,18 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
 	DoubleFlags.jl (Syntax), ();
 
         // on the following file, javac produces an error, but we intentionally do not.
-        //  BadFinalInit13.jl (Post); 
+        //  BadFinalInit13.jl (Post);
 
-	BadForwardRef.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef2.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef3.jl (Semantic, "Illegal forward ref"); 
+	BadForwardRef.jl (Semantic, "Illegal forward ref");
+	BadForwardRef2.jl (Semantic, "Illegal forward ref");
+	BadForwardRef3.jl (Semantic, "Illegal forward ref");
         Continue1.jl (Semantic, "Target.*not found"), (), (), ();
         Continue2.jl (Semantic, "must be a loop"), (), (), ();
-	ForwardRef4.jl (Semantic, "Illegal forward ref"); 
-	ForwardRef5.jl; 
+	ForwardRef4.jl (Semantic, "Illegal forward ref");
+	ForwardRef5.jl;
 	// the following test has exactly 4 errors in it
-	ForwardRef6.jl (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"); 
+	ForwardRef6.jl (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref");
 }

--- a/testsjl7/pthScript
+++ b/testsjl7/pthScript
@@ -15,23 +15,23 @@
 #                    |  ( ErrorKind, "RegExp" )
 #                    |  ( "RegExp" )
 #                    |  ( )
-#      ErrorKind    :   one of, or a unique prefix of one of the following 
-#                       strings: "Warning", "Internal Error", "I/O Error", 
+#      ErrorKind    :   one of, or a unique prefix of one of the following
+#                       strings: "Warning", "Internal Error", "I/O Error",
 #                       "Lexical Error", "Syntax Error", "Semantic Error"
 #                       or "Post-compiler Error".
-#      Filename     :   the name of a file. Is interpreted from the 
+#      Filename     :   the name of a file. Is interpreted from the
 #                       directory where pth is run.
 #      LitString    :   a literal string, enclosed in quotes.
-#      RegExp       :   a regular expression, as in java.util.regex; 
+#      RegExp       :   a regular expression, as in java.util.regex;
 #                       is always enclosed in quotes.
-#      CmdLineArgs  :   additional command line args for the Polyglot 
+#      CmdLineArgs  :   additional command line args for the Polyglot
 #                       compiler; is always enclosed in quotes.
 
 # Compile some java classes first
 #javac "-d java-out -cp ." {
 #}
- 
-polyglot.ext.jl7.JL7ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-source 1.7 -Xlint\\:-options\" -morepermissiveinference" {
+
+polyglot.ext.jl7.JL7ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
 	Diamond01.jl7;
 	Diamond02.jl7 (Semantic, "type arguments cannot be used");
 	Diamond03.jl7 (Semantic, "anonymous class");
@@ -49,10 +49,10 @@ polyglot.ext.jl7.JL7ExtensionInfo "-d out -classpath java-out -assert -noserial 
 	IntLit02b.jl7 ("Could not find") , ("Could not find"); // 2 errors
 	IntLit02c.jl7 (Syntax);
 	IntLit03.jl7;
-	IntLit04.jl7 ("out of range"),("unexpected .* literal"), 
-	             ("out of range"),("unexpected .* literal"), 
+	IntLit04.jl7 ("out of range"),("unexpected .* literal"),
+	             ("out of range"),("unexpected .* literal"),
 	             ("out of range"),("out of range"),("out of range"),
-	             ("out of range"),("unexpected .* literal"), 
+	             ("out of range"),("unexpected .* literal"),
 	             ("out of range"),("unexpected .* literal"); // 11 errors
 	MultiCatch01.jl7;
 	MultiCatch02.jl7 (Semantic);

--- a/testsjl7/pthScript-JL
+++ b/testsjl7/pthScript-JL
@@ -4,7 +4,7 @@ javac ["../tests/"] "-d java-out -cp ." {
 	java-src/ClassFile02.java;
 }
 
-polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-out -assert -noserial -postopts \"-source 1.7 -Xlint\\:-options\" -morepermissiveinference" {
+polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
         AnonymousClass.jl ;
         AnonymousClass02.jl ;
         AnonymousClass03.jl;
@@ -48,20 +48,20 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         ClassFile01.jl;
         ClassFile02.jl;
         ClassLit.jl ;
-	CombRule1.jl; 
+	CombRule1.jl;
 	CombRule2.jl (Semantic, "Method.*cannot be called with arguments");
 	CombRule3.jl (Semantic, "Method.*cannot be called with arguments");
         Conditional1.jl ;
 	ConformanceCheck1.jl (Semantic, "cannot override.*attempting to assign weaker access");
 	ConformanceCheck2.jl (Semantic, "cannot override.*throw set.*is not a subset");
-        ConformanceCheck3.jl ;        
+        ConformanceCheck3.jl ;
         ConformanceCheck4.jl ConformanceCheck4a.jl (Semantic, "should be declared abstract");
-        ConformanceCheck5.jl ;        
-        ConformanceCheck6.jl ;         
-        ConformanceCheck7.jl (Semantic, "should be declared abstract");        
-        packA/ConformanceCheck8.jl packB/ConformanceCheck8b.jl (Semantic, "should be declared abstract"); 
-        ConformanceCheck9.jl ;         
-        ConformanceCheck10.jl packA/ConformanceCheck10a.jl packA/ConformanceCheck10b.jl; 
+        ConformanceCheck5.jl ;
+        ConformanceCheck6.jl ;
+        ConformanceCheck7.jl (Semantic, "should be declared abstract");
+        packA/ConformanceCheck8.jl packB/ConformanceCheck8b.jl (Semantic, "should be declared abstract");
+        ConformanceCheck9.jl ;
+        ConformanceCheck10.jl packA/ConformanceCheck10a.jl packA/ConformanceCheck10b.jl;
         packA/ProtectedAccess1.jl packB/ProtectedAccess2.jl (Semantic, "Method.*inaccessible");
         package1/ProtectedTest.jl package2/ProtectedTestBase.jl (Semantic, "Method.*inaccessible");
         package1/InnerClassAccess.jl package1/InnerClassProblem.jl ;
@@ -130,9 +130,9 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         Init1.jl ; Init2.jl ; Init3.jl ; Init4.jl ; Init5.jl ;
         Init6.jl ;
         Init7.jl ; Init8.jl ; Init9.jl ;
-	Init10.jl; 
-	Init11.jl; 
-	Init12.jl; 
+	Init10.jl;
+	Init11.jl;
+	Init12.jl;
 	Init13.jl;
 	Init14.jl;
 	Init15.jl;
@@ -194,8 +194,8 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
                         (Lexical, "Long literal.*out of range"),
                         (Syntax);
         Local.jl ;
-        LocalClass.jl ; 
-#        LocalClass2.jl ; 
+        LocalClass.jl ;
+#        LocalClass2.jl ;
         LocalClass3.jl ; LocalClass4.jl ;
 	LocalClass5.jl ;
 	LocalClass6.jl (Semantic, "Circular inheritance");
@@ -229,7 +229,7 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         Package01a.jl Package01b.jl Package01c.jl (Semantic, "imported type .* not canonical");
         Package02.jl (Semantic, "imported type .* not visible");
         Prim.jl ;
-        Prec.jl ; 
+        Prec.jl ;
 	Prec2.jl ;
 	Prec3.jl ;
 	Protection.jl (Semantic, "Cannot declare abstract method with flags static"),
@@ -258,7 +258,7 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         StaticMethod.jl ;
         StaticOps.jl ;
         Switch1.jl ; Switch2.jl ; Switch3.jl ; Switch4.jl ; Switch5.jl ;
-        Switch6.jl ; 
+        Switch6.jl ;
 #        Switch7.jl ;
         Switch08.jl (Semantic, "not assignable");
         Synchronized01.jl (Semantic, "Cannot synchronize");
@@ -290,8 +290,8 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         BadFinalInit11.jl (Semantic, "Final field .* might already have been initialized");
         BadFinalInit12.jl (Semantic, "Cannot assign a value to final field");
         BadFinalInit14.jl (Semantic, "Cannot assign a value to final field");
-        BadFinalInit15.jl (Semantic, "Final variable .* might already have been initialized"); 
-        BadFinalInit16.jl (Semantic, "Local variable .* may not have been initialized"); 
+        BadFinalInit15.jl (Semantic, "Final variable .* might already have been initialized");
+        BadFinalInit16.jl (Semantic, "Local variable .* may not have been initialized");
         BadFinalInit17.jl (Semantic, "Final field .* might not have been initialized");
         BadIncrement1.jl (Semantic, "Operand of .* operator must be a variable");
         BadIncrement2.jl (Semantic, "Operand of .* operator must be a variable");
@@ -316,11 +316,11 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
 	BadMultipleVarDef.jl (Semantic, "Local variable .* multiply defined"),
 			     (Semantic, "Local variable .* multiply defined");
 	BadOverride.jl (Semantic, "cannot override.*attempting to assign weaker access privileges");
-	BadPrim.jl (Semantic, "Method.*cannot be called with arguments"); 
+	BadPrim.jl (Semantic, "Method.*cannot be called with arguments");
 	BadProt.jl (Semantic, "Interface methods must be public");
 	BadReferences.jl (Semantic, "Member.*ambiguous");
 	BadReferences2.jl (Semantic, "Field.*ambiguous");
-	BadStaticContext.jl (Semantic); 
+	BadStaticContext.jl (Semantic);
         BadSwitch1.jl (Semantic, "Case label must be an integral constant");
 	BadSwitch2.jl (Semantic, "Duplicate case label");
 	Constants12.jl (Semantic, "Duplicate case label"),
@@ -333,21 +333,21 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         CircularInheritance2.jl (Semantic, "Circular inheritance");
         CircularInheritance3.jl (Semantic, "Circular inheritance");
 	Errors.jl (Semantic, "Method.*cannot be called with arguments");
-	Errors2.jl (Semantic, "Class .* not found"); 
-	LabeledBreak2.jl (Semantic, "Unreachable statement"); 
+	Errors2.jl (Semantic, "Class .* not found");
+	LabeledBreak2.jl (Semantic, "Unreachable statement");
         InitCheckerBug.jl ;
-	NoInit1.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit10.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit11.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit12.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit2.jl (Semantic, "Local variable .* may not have been initialized"); 
+	NoInit1.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit10.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit11.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit12.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit2.jl (Semantic, "Local variable .* may not have been initialized");
 	NoInit3.jl (Semantic, "Unreachable statement");
-	NoInit4.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit5.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit6.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit7.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit8.jl (Semantic, "Local variable .* may not have been initialized"); 
-	NoInit9.jl (Semantic, "Local variable .* may not have been initialized"); 
+	NoInit4.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit5.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit6.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit7.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit8.jl (Semantic, "Local variable .* may not have been initialized");
+	NoInit9.jl (Semantic, "Local variable .* may not have been initialized");
 	StaticContext2.jl (Semantic, "Inner classes cannot declare static methods");
 	NoReturn1.jl  (Semantic, "Missing return statement");
 	NoReturn2.jl (Semantic, "Missing return statement");
@@ -376,18 +376,18 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
 	DoubleFlags.jl (Syntax), ();
 
         // on the following file, javac produces an error, but we intentionally do not.
-        //  BadFinalInit13.jl (Post); 
+        //  BadFinalInit13.jl (Post);
 
-	BadForwardRef.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef2.jl (Semantic, "Illegal forward ref"); 
-	BadForwardRef3.jl (Semantic, "Illegal forward ref"); 
+	BadForwardRef.jl (Semantic, "Illegal forward ref");
+	BadForwardRef2.jl (Semantic, "Illegal forward ref");
+	BadForwardRef3.jl (Semantic, "Illegal forward ref");
         Continue1.jl (Semantic, "Target.*not found"), (), (), ();
         Continue2.jl (Semantic, "must be a loop"), (), (), ();
-	ForwardRef4.jl (Semantic, "Illegal forward ref"); 
-	ForwardRef5.jl; 
+	ForwardRef4.jl (Semantic, "Illegal forward ref");
+	ForwardRef5.jl;
 	// the following test has exactly 4 errors in it
-	ForwardRef6.jl (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"), 
-		       (Semantic, "Illegal forward ref"); 
+	ForwardRef6.jl (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref"),
+		       (Semantic, "Illegal forward ref");
 }

--- a/testsjl7/pthScript-JL5
+++ b/testsjl7/pthScript-JL5
@@ -10,8 +10,8 @@ javac ["../testsjl5/"] "-d java-out -cp ." {
 	java-src/Call02B.java;
 	java-src/Call02D.java;
 }
- 
-polyglot.ext.jl7.JL7ExtensionInfo ["../testsjl5/"] "-sx jl5 -d out -classpath java-out -assert -noserial -postopts \"-source 1.7 -Xlint\\:-options\" -morepermissiveinference" {
+
+polyglot.ext.jl7.JL7ExtensionInfo ["../testsjl5/"] "-sx jl5 -d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
         Assert01.jl5;
         HexFloatingPoint.jl5;
         Generics01.jl5;
@@ -34,7 +34,7 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../testsjl5/"] "-sx jl5 -d out -classpath ja
         Generics18.jl5 (Post, "Xlint");
         Generics19.jl5;
         Generics20.jl5 (Semantic);
-        Generics21.jl5 (Semantic); 
+        Generics21.jl5 (Semantic);
         Generics22.jl5 (Semantic);
         Generics23.jl5 (Semantic);
         Generics24.jl5 (Semantic, "Wrong number of type parameters"),
@@ -42,7 +42,7 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../testsjl5/"] "-sx jl5 -d out -classpath ja
                        (Semantic, "Cannot instantiate .* because it has no formals");
         Generics25.jl5 (Semantic);
         Generics26.jl5 (Post, "Xlint");
-        Generics27.jl5;        
+        Generics27.jl5;
         Generics28.jl5 (Post, "Xlint");
         Generics29.jl5 (Post, "Xlint");
         Generics30.jl5 (Semantic);
@@ -50,7 +50,7 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../testsjl5/"] "-sx jl5 -d out -classpath ja
         Generics32.jl5;
         Generics33.jl5 (Semantic);
         Generics34.jl5;
-        Generics35.jl5 (Semantic); 
+        Generics35.jl5 (Semantic);
         Generics36.jl5;
         Generics37.jl5;
         Generics38.jl5;
@@ -282,24 +282,24 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../testsjl5/"] "-sx jl5 -d out -classpath ja
         wildcard7.jl5 (Semantic), (Semantic), (Semantic);
         wildcard7a.jl5;
         wildcard8.jl5 (Semantic);
-        wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"); 
-        wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match"); 
-        wildcard12a.jl5(Semantic); 
-        wildcard12b.jl5(Semantic); 
-        wildcard12c.jl5(Semantic); 
-        wildcard12d.jl5(Semantic); 
-        wildcard12e.jl5; 
-        wildcard13a.jl5 (Semantic); 
-        wildcard13b.jl5 (Semantic); 
-        wildcard13c.jl5 (Semantic); 
-        wildcard13d.jl5; 
-        wildcard14a.jl5 (Semantic); 
-        wildcard14b.jl5 (Semantic); 
-        wildcard14c.jl5 (Semantic); 
-        wildcard14d.jl5 ; 
-        wildcard15.jl5 (Semantic),(Semantic); 
+        wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match");
+        wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match");
+        wildcard12a.jl5(Semantic);
+        wildcard12b.jl5(Semantic);
+        wildcard12c.jl5(Semantic);
+        wildcard12d.jl5(Semantic);
+        wildcard12e.jl5;
+        wildcard13a.jl5 (Semantic);
+        wildcard13b.jl5 (Semantic);
+        wildcard13c.jl5 (Semantic);
+        wildcard13d.jl5;
+        wildcard14a.jl5 (Semantic);
+        wildcard14b.jl5 (Semantic);
+        wildcard14c.jl5 (Semantic);
+        wildcard14d.jl5 ;
+        wildcard15.jl5 (Semantic),(Semantic);
         wildcard16.jl5 (Semantic, "Cannot assign long to");
-        wildcard17.jl5 (Semantic),(Semantic),(Semantic); 
+        wildcard17.jl5 (Semantic),(Semantic),(Semantic);
         wildcard18.jl5 (Semantic);
         wildcard19.jl5 (Semantic, "not a subtype .* bound") , (Semantic);
         wildcard20.jl5 (Semantic, "cannot be called");


### PR DESCRIPTION
## Summary

#7 adds support for Java 9. However, the support seems to be incomplete. While it adds support for class loading for Java 9+ due to missing `rt.jar` and `tools.jar` since Java 9, we still have other code that depends on the layout of JDK prior to Java 9.

One such example is our code to detect whether a package exists.

https://github.com/polyglot-compiler/polyglot/blob/3b791b645841db5fe676b97b55a628c6709770e6/src/polyglot/filemanager/ExtFileManager.java#L404-L435

This code works fine for Java <= 8, since the builtin java packages exist physically on the disk and allow inspection. This is no longer true for JDK 9+. See [JDK 9 migration guide: Removed rt.jar and tools.jar](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-A78CC891-701D-4549-AA4E-B8DD90228B4B). As a result, no directory will be in `StandardLocation.PLATFORM_CLASS_PATH`, which causes the code to incorrectly report that a builtin Java package does not exist. (Again, this does not impact class loading for fully qualified class due to the fix in #7). Such failure causes quite a few test failures.

I fixed this by reading the file in `$JAVA_HOME/lib/classlist`, which contains all the builtin java classes in the form of `java/lang/String`. Then the content of the files are pre-populated into the package cache at initialization. This ensures that all correct package existence checks are able to pass.

## Test Plan

```sh
cd tests
PATH="<JAVA_HOME of java 11>/bin/:$PATH" ../bin/pth pthScript
PATH="<JAVA_HOME of java 8>/bin/:$PATH" ../bin/pth pthScript
```

Both say 387/391 test cases succeed, which shows that the support for Java 11 is finished.