### PR TITLE
Remove uses of deprecated Integer/Double constructor in tests

### DIFF
--- a/testsjl5/ArrayInit01.jl5
+++ b/testsjl5/ArrayInit01.jl5
@@ -1,5 +1,5 @@
 class C {
-  void m() { 
-    Object[] a = new Object[] {4, 5, new Integer(6)};
+  void m() {
+    Object[] a = new Object[] {4, 5, Integer.valueOf(6)};
   }
 }

--- a/testsjl5/ArrayInit03.jl5
+++ b/testsjl5/ArrayInit03.jl5
@@ -1,5 +1,5 @@
 class C {
-  void m() { 
-      Object[] a = {4, 5, new Integer(7)};
+  void m() {
+      Object[] a = {4, 5, Integer.valueOf(7)};
   }
 }

--- a/testsjl5/GenericMethod12.jl5
+++ b/testsjl5/GenericMethod12.jl5
@@ -3,10 +3,10 @@ class Test {
 	<T> T method(T a, T b) {
 	   return null;
 	}
-	
+
 	void test() {
-	   Comparable<? extends Comparable<? extends Comparable<?>>> t = method(new String(), new Integer(5));
+	   Comparable<? extends Comparable<? extends Comparable<?>>> t = method(new String(), Integer.valueOf(5));
 	   String a = method("5",4);
-	   
+
 	}
 }

--- a/testsjl5/Generics27.jl5
+++ b/testsjl5/Generics27.jl5
@@ -1,29 +1,29 @@
 // from JLS Java SE 7 ed., Example 8.1.2-1
-class Seq<T> { 
-    T head; 
-    Seq<T> tail; 
-    Seq() { 
-	this(null, null); 
-    } 
-    boolean isEmpty() { 
-	return tail == null; 
+class Seq<T> {
+    T head;
+    Seq<T> tail;
+    Seq() {
+	this(null, null);
     }
-    Seq(T head, Seq<T> tail) { 
-	this.head = head; 
-	this.tail = tail; 
+    boolean isEmpty() {
+	return tail == null;
     }
-    class Zipper<S> { 
-	Seq<Pair<T,S>> zip(Seq<S> that) { 
+    Seq(T head, Seq<T> tail) {
+	this.head = head;
+	this.tail = tail;
+    }
+    class Zipper<S> {
+	Seq<Pair<T,S>> zip(Seq<S> that) {
 	    if (isEmpty() || that.isEmpty())
-		return new Seq<Pair<T,S>>(); 
-	    else 
-		return new Seq<Pair<T,S>>(new Pair<T,S>(Seq.this.head, that.head), 
+		return new Seq<Pair<T,S>>();
+	    else
+		return new Seq<Pair<T,S>>(new Pair<T,S>(Seq.this.head, that.head),
 					  tail.new Zipper<S>().zip(that.tail));
 	}
     }
 }
 class Pair<T, S> {
-    T fst; 
+    T fst;
     S snd;
     Pair(T f, S s) {
 	fst = f; snd = s;
@@ -32,14 +32,14 @@ class Pair<T, S> {
 
 class Client {
     {
-	Seq<String> strs = 
-	    new Seq<String>("a", new Seq<String>("b", 
+	Seq<String> strs =
+	    new Seq<String>("a", new Seq<String>("b",
 						 new Seq<String>()));
-	Seq<Number> nums = 
-	    new Seq<Number>(new Integer(1), 
-			    new Seq<Number>(new Double(1.5), 
+	Seq<Number> nums =
+	    new Seq<Number>(Integer.valueOf(1),
+			    new Seq<Number>(Double.valueOf(1.5),
 					    new Seq<Number>()));
-	Seq<String>.Zipper<Number> zipper = 
+	Seq<String>.Zipper<Number> zipper =
 	    strs.new Zipper<Number>();
 	Seq<Pair<String,Number>> combined = zipper.zip(nums);
     }

--- a/testsjl5/InnerClass12.jl5
+++ b/testsjl5/InnerClass12.jl5
@@ -1,28 +1,28 @@
-class Seq { 
-	Object head; 
-	Seq tail; 
-	Seq() { 
-		this(null, null); 
-	} 
-	boolean isEmpty() { 
-		return tail == null; 
+class Seq {
+	Object head;
+	Seq tail;
+	Seq() {
+		this(null, null);
 	}
-	Seq(Object head, Seq tail) { 
-		this.head = head; 
-		this.tail = tail; 
+	boolean isEmpty() {
+		return tail == null;
 	}
-	class Zipper<S> { 
-		Seq zip(Seq that) { 
+	Seq(Object head, Seq tail) {
+		this.head = head;
+		this.tail = tail;
+	}
+	class Zipper<S> {
+		Seq zip(Seq that) {
 			if (isEmpty() || that.isEmpty())
-				return new Seq(); 
-			else 
-				return new Seq(new Pair<Object,Object>(Seq.this.head, that.head), 
+				return new Seq();
+			else
+				return new Seq(new Pair<Object,Object>(Seq.this.head, that.head),
 						tail.new Zipper<S>().zip(that.tail));
 		}
 	}
 }
 class Pair<T, S> {
-	T fst; 
+	T fst;
 	S snd;
 	Pair(T f, S s) {
 		fst = f; snd = s;
@@ -30,14 +30,14 @@ class Pair<T, S> {
 }
 
 class Client {
-	Seq strs = 
-			new Seq("a", new Seq("b", 
+	Seq strs =
+			new Seq("a", new Seq("b",
 					new Seq()));
-	Seq nums = 
-			new Seq(new Integer(1), 
-					new Seq(new Double(1.5), 
+	Seq nums =
+			new Seq(Integer.valueOf(1),
+					new Seq(Double.valueOf(1.5),
 							new Seq()));
-	Seq.Zipper<Number> zipper = 
+	Seq.Zipper<Number> zipper =
 			strs.new Zipper<Number>();
 	Seq combined = zipper.zip(nums);
 }

--- a/testsjl5/Lists5.jl5
+++ b/testsjl5/Lists5.jl5
@@ -4,6 +4,6 @@ class C {
     void m() {
 	List<Object> l = new LinkedList<Object>();
 	l.add("hello");
-	l.add(new Integer(3));
+	l.add(Integer.valueOf(3));
     }
 }

--- a/testsjl5/pthScript
+++ b/testsjl5/pthScript
@@ -378,8 +378,8 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
         StringTest.jl5;
         StringTest01.jl5;
         Switch01.jl5;
-        Switch02.jl5 (Semantic, "Case label");
-        Switch03.jl5 (Semantic, "Case label");
+        Switch02.jl5 (Semantic, "Case label"), (Semantic, "Case label");
+        Switch03.jl5 (Semantic, "Case label"), (Semantic, "Case label");
         TC12.jl5;
         TC195.jl5;
         test1.jl5;
@@ -802,8 +802,8 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         StringTest.jl5;
         StringTest01.jl5;
         Switch01.jl5;
-        Switch02.jl5 (Semantic, "Case label");
-        Switch03.jl5 (Semantic, "Case label");
+        Switch02.jl5 (Semantic, "Case label"), (Semantic, "Case label");
+        Switch03.jl5 (Semantic, "Case label"), (Semantic, "Case label");
         TC12.jl5;
         TC195.jl5;
         test1.jl5;

--- a/testsjl5/wildcard12e.jl5
+++ b/testsjl5/wildcard12e.jl5
@@ -1,7 +1,7 @@
 class Box< T > {
-  public T t; 
+  public T t;
   public boolean equalTo( Box< T > other) { return this.t.equals(other.t); }
-  
+
       public Box(T t) { this.t = t; }
       public void put( T t) { this.t = t;}
       public T take() { return t; }
@@ -9,17 +9,17 @@ class Box< T > {
       public boolean contains( T t) { return this.t == t; }
       public String toString() { return "Box["+t.toString()+"]"; }
   public void takeContentFrom( Box<? extends T > box) { t = box.t; }
-  public Class<? extends T > getContentType() { return null;} 
+  public Class<? extends T > getContentType() { return null;}
   public int compareTo( Comparable<? super T > other) { return other.compareTo(t); }
-  public Box<? super T > copy() { return new Box<T>(t); }  
+  public Box<? super T > copy() { return new Box<T>(t); }
 }
 
 class Test {
   public static void main(String[] args) {
-    Box<Number> numberBox = new Box<Number>(5L); 
-    Box<?> unknownBox = numberBox; 
+    Box<Number> numberBox = new Box<Number>(5L);
+    Box<?> unknownBox = numberBox;
 
-    Comparable<?> comparableToUnknown = new Integer(1);
+    Comparable<?> comparableToUnknown = Integer.valueOf(1);
     Comparable<Object> comparableToObject = null;
     Comparable<? super Number> comparableToNumber = comparableToObject;
 
@@ -28,4 +28,4 @@ class Test {
 
     Box<?>                box1 = unknownBox.copy(); // ok
     }
-} 
+}

--- a/testsjl5/wildcard13d.jl5
+++ b/testsjl5/wildcard13d.jl5
@@ -1,7 +1,7 @@
 class Box< T > {
-  public T t; 
+  public T t;
   public boolean equalTo( Box< T > other) { return this.t.equals(other.t); }
-  
+
       public Box(T t) { this.t = t; }
       public void put( T t) { this.t = t;}
       public T take() { return t; }
@@ -9,17 +9,17 @@ class Box< T > {
       public boolean contains( T t) { return this.t == t; }
       public String toString() { return "Box["+t.toString()+"]"; }
   public void takeContentFrom( Box<? extends T > box) { t = box.t; }
-  public Class<? extends T > getContentType() { return null;} 
+  public Class<? extends T > getContentType() { return null;}
   public int compareTo( Comparable<? super T > other) { return other.compareTo(t); }
-  public Box<? super T > copy() { return new Box<T>(t); }  
+  public Box<? super T > copy() { return new Box<T>(t); }
 }
 
 class Test {
   public static void main(String[] args) {
-    Box<Number> numberBox = new Box<Number>(5L); 
-    Box<? extends Number> unknownBox = numberBox; 
+    Box<Number> numberBox = new Box<Number>(5L);
+    Box<? extends Number> unknownBox = numberBox;
 
-    Comparable<?> comparableToUnknown = new Integer(1);
+    Comparable<?> comparableToUnknown = Integer.valueOf(1);
     Comparable<Object> comparableToObject = null;
     Comparable<? super Number> comparableToNumber = comparableToObject;
 
@@ -29,4 +29,4 @@ class Test {
 
     Box<?>                box1 = unknownBox.copy(); // ok
     }
-} 
+}

--- a/testsjl5/wildcard14d.jl5
+++ b/testsjl5/wildcard14d.jl5
@@ -1,7 +1,7 @@
 class Box< T > {
-  public T t; 
+  public T t;
   public boolean equalTo( Box< T > other) { return this.t.equals(other.t); }
-  
+
       public Box(T t) { this.t = t; }
       public void put( T t) { this.t = t;}
       public T take() { return t; }
@@ -9,17 +9,17 @@ class Box< T > {
       public boolean contains( T t) { return this.t == t; }
       public String toString() { return "Box["+t.toString()+"]"; }
   public void takeContentFrom( Box<? extends T > box) { t = box.t; }
-  public Class<? extends T > getContentType() { return null;} 
+  public Class<? extends T > getContentType() { return null;}
   public int compareTo( Comparable<? super T > other) { return other.compareTo(t); }
-  public Box<? super T > copy() { return new Box<T>(t); }  
+  public Box<? super T > copy() { return new Box<T>(t); }
 }
 
 class Test {
   public static void main(String[] args) {
-    Box<Number> numberBox = new Box<Number>(5L); 
-    Box<? super Number> unknownBox = numberBox; 
+    Box<Number> numberBox = new Box<Number>(5L);
+    Box<? super Number> unknownBox = numberBox;
 
-    Comparable<?> comparableToUnknown = new Integer(1);
+    Comparable<?> comparableToUnknown = Integer.valueOf(1);
     Comparable<Object> comparableToObject = null;
     Comparable<? super Number> comparableToNumber = comparableToObject;
 
@@ -29,4 +29,4 @@ class Test {
     Box<?>                box1 = unknownBox.copy(); // ok
     Box<? super Number>   box3 = unknownBox.copy();  // ok
     }
-} 
+}

--- a/testsjl5/wildcard7a.jl5
+++ b/testsjl5/wildcard7a.jl5
@@ -1,5 +1,5 @@
     class Box<T> {
-      private T t; 
+      private T t;
 
       public Box(T t) { this.t = t; }
       public void put( T t) { this.t = t;}
@@ -11,7 +11,7 @@
     class Test {
       public static void main(String[] args) {
         Box<? super Long > box = new Box<Number>(0L);
-        Number number = new Integer(1);
+        Number number = Integer.valueOf(1);
 
         box.put(1L);      // ok
         box.put(null);     // ok
@@ -21,4 +21,4 @@
 
        Object o = box.take(); // ok
       }
-    } 
+    }


### PR DESCRIPTION
These APIs are deprecated since Java 9. Replacing them with `.valueOf` ones removes the XLint warning and make tests pass.