### PR TITLE
Fix most of the failed test cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Build Jar
         run: ant jar
       - name: Run Base Tests
-        run: ../bin/pth pthScript
+        run: ../bin/pth -ec pthScript
         working-directory: ./tests
+      - name: Run JL7 Tests
+        run: ../bin/pth -ec pthScript
+        working-directory: ./testsjl7

--- a/testsjl5/packA/.gitignore
+++ b/testsjl5/packA/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl5/packB/.gitignore
+++ b/testsjl5/packB/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl5/package1/.gitignore
+++ b/testsjl5/package1/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl5/package2/.gitignore
+++ b/testsjl5/package2/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl5/pthScript
+++ b/testsjl5/pthScript
@@ -409,8 +409,8 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
         VarArgs04.jl5;
         VarArgs05.jl5;
         VarArgs06.jl5;
-        VarArgs07.jl5;
-        VarArgs08.jl5 (Post, "Xlint");
+        VarArgs07.jl5 (Post, "Xlint:unchecked");
+        VarArgs08.jl5 (Post, "Xlint:unchecked");
         VarArgs09.jl5;
         VarArgs10.jl5;
         VarArgs11.jl5 (Semantic, "Method .* cannot be called");
@@ -463,7 +463,6 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -assert -noserial 
 }
 
 # Now run the tests again removing the Java 5-isms.
-# This one uses 1.4 to suppress the warning about raw classes.
 polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -enumImplClass MyEnum -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
         Access01.jl5;
         Access02.jl5;
@@ -489,7 +488,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Annotations16.jl5;
         Annotations17.jl5;
         Annotations18.jl5;
-        Annotations19.jl5;
+        Annotations19.jl5 (Post, "Xlint:unchecked");
         Annotations20.jl5;
         Annotations21.jl5;
         Annotations22.jl5  (Semantic, "not applicable");
@@ -500,7 +499,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Array2.jl5 (Semantic, "Name clash"), (Semantic, "should be declared abstract");
         Array03.jl5;
         Array04.jl5;
-        Array05.jl5;
+        Array05.jl5 (Post, "Xlint:unchecked");
         Array06.jl5;
         Array07.jl5 (Semantic, "reifiable");
         Array08.jl5;
@@ -525,7 +524,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Cast04.jl5;
         Cast05.jl5;
         ClassLoad01.jl5;
-        ClassLoad02.jl5;
+        ClassLoad02.jl5 (Post, "Xlint:unchecked");
         Conditional01.jl5;
         Conditional02.jl5;
         Conditional03.jl5;
@@ -538,7 +537,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Conditional10.jl5 (Semantic, "does not match");
         Conditional11.jl5;
         Conditional12.jl5;
-        Constant01.jl5;
+        Constant01.jl5 (Post, "Xlint:unchecked");
         ConstructorCall01.jl5;
         CovariantRet01.jl5;
         CovariantRet02.jl5;
@@ -546,25 +545,25 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         CovariantRet04.jl5; #Known bug!
         CovariantRet05.jl5 (Semantic, "incompatible return");
         dotclass.jl5;
-        enum1.jl5;
+        enum1.jl5 (Post, "Xlint:unchecked");
         enum2.jl5;
-        EnumTest1.jl5;
-        EnumTest2.jl5;
-        EnumTest3.jl5;
-        EnumTest4.jl5;
+        EnumTest1.jl5 (Post, "Xlint:unchecked");
+        EnumTest2.jl5 (Post, "Xlint:unchecked");
+        EnumTest3.jl5 (Post, "Xlint:unchecked");
+        EnumTest4.jl5 (Post, "Xlint:unchecked");
         EnumTest5.jl5;
-        EnumTest6.jl5;
-        EnumTest7.jl5;
-        EnumTest8.jl5;
-        EnumTest9.jl5;
-        EnumTest11.jl5;
-        EnumTest12.jl5;
-        EnumTest13.jl5;
+        EnumTest6.jl5 (Post, "Xlint:unchecked");
+        EnumTest7.jl5 (Post, "Xlint:unchecked");
+        EnumTest8.jl5 (Post, "Xlint:unchecked");
+        EnumTest9.jl5 (Post, "Xlint:unchecked");
+        EnumTest11.jl5 (Post, "Xlint:unchecked");
+        EnumTest12.jl5 (Post, "Xlint:unchecked");
+        EnumTest13.jl5 (Post, "Xlint:unchecked");
         EnumTest14.jl5;
-        EnumTest15.jl5;
-        EnumTest16.jl5;
-        EnumTest17.jl5;
-        EnumTest18.jl5;
+        EnumTest15.jl5 (Post, "Xlint:unchecked");
+        EnumTest16.jl5 (Post, "Xlint:unchecked");
+        EnumTest17.jl5 (Post, "Xlint:unchecked");
+        EnumTest18.jl5 (Post, "Xlint:unchecked");
         error1.jl5 (Semantic, "should be declared abstract");
         error3.jl5 (Semantic, "Name clash");
         error3b.jl5;
@@ -578,7 +577,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         error5.jl5 (Semantic, "type .* does not match");
         error6.jl5 (Semantic, "Name clash"), (Semantic, "should be declared abstract");
         error7.jl5 (Semantic, "not a subtype");
-        exn1.jl5;
+        exn1.jl5 (Post, "Xlint:unchecked");
         exn2.jl5;
         ExtFor01.jl5;
         ExtFor02.jl5;
@@ -599,18 +598,18 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Generic.jl5;
         GenericConstructor01.jl5 (Semantic, "cannot be invoked");
         GenericConstructor02.jl5 (Semantic, "Duplicate constructor");
-        GenericMethod1.jl5;
+        GenericMethod1.jl5 (Post, "Xlint:unchecked");
         GenericMethod1a.jl5 (Semantic);
         GenericMethod2.jl5 (Semantic);
         GenericMethod3.jl5;
-        GenericMethod4.jl5;
-        GenericMethod5.jl5;
+        GenericMethod4.jl5 (Post, "Xlint:unchecked");
+        GenericMethod5.jl5 (Post, "Xlint:unchecked");
         GenericMethod5a.jl5 (Semantic);
         GenericMethod06.jl5;
-        GenericMethod7.jl5;
-        GenericMethod7a.jl5;
-        GenericMethod8.jl5;
-        GenericMethod8a.jl5;
+        GenericMethod7.jl5 (Post, "Xlint:unchecked");
+        GenericMethod7a.jl5 (Post, "Xlint:unchecked");
+        GenericMethod8.jl5 (Post, "Xlint:unchecked");
+        GenericMethod8a.jl5 (Post, "Xlint:unchecked");
         GenericMethod8b.jl5;
         GenericMethod9.jl5;
         GenericMethod9a.jl5 (Semantic);
@@ -678,7 +677,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Generics47.jl5 ;
         Generics48.jl5;
         Generics49.jl5;
-        Generics50.jl5;
+        Generics50.jl5 (Post, "Xlint:unchecked");
         Generics51.jl5;
         Generics52.jl5;
         Generics53.jl5;
@@ -711,7 +710,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         InnerClass08.jl5;
         InnerClass09.jl5;
         InnerClass10.jl5;
-        InnerClass11.jl5;
+        InnerClass11.jl5 (Post, "Xlint:unchecked");
         InnerClass12.jl5;
         InnerClass13.jl5;
         InnerClass14.jl5;
@@ -732,12 +731,12 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         intersection.jl5 (Semantic, "inaccessible"), (Semantic, "inaccessible");
         Iterator01.jl5;
         JLS8.1.2.jl5;
-        Lists1.jl5;
-        Lists2.jl5;
-        Lists3.jl5;
-        Lists4.jl5;
-        Lists5.jl5;
-        Lists6.jl5;
+        Lists1.jl5 (Post, "Xlint:unchecked");
+        Lists2.jl5 (Post, "Xlint:unchecked");
+        Lists3.jl5 (Post, "Xlint:unchecked");
+        Lists4.jl5 (Post, "Xlint:unchecked");
+        Lists5.jl5 (Post, "Xlint:unchecked");
+        Lists6.jl5 (Post, "Xlint:unchecked");
         Lists7.jl5 (Semantic);
         Lists8.jl5 (Semantic);
         Lists9.jl5 (Semantic);
@@ -747,7 +746,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Method02.jl5;
         Method03.jl5;
         Method04.jl5;
-        Method05.jl5;
+        Method05.jl5 (Post, "Xlint:unchecked");
         Method06.jl5;
         Negate01.jl5;
         Nested01.jl5;
@@ -804,7 +803,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         Switch01.jl5;
         Switch02.jl5 (Semantic, "Case label"), (Semantic, "Case label");
         Switch03.jl5 (Semantic, "Case label"), (Semantic, "Case label");
-        TC12.jl5;
+        TC12.jl5 (Post, "Xlint:unchecked");
         TC195.jl5;
         test1.jl5;
         test2.jl5;
@@ -836,7 +835,7 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         VarArgs07.jl5;
         VarArgs08.jl5;
         VarArgs09.jl5;
-        VarArgs10.jl5;
+        VarArgs10.jl5 (Post, "Xlint:unchecked");
         VarArgs11.jl5 (Semantic, "Method .* cannot be called");
         VerySimple.jl5;
         WildCard01.jl5;
@@ -845,10 +844,10 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         WildCard04.jl5;
         WildCard05.jl5;
         WildCard06.jl5; # TODO
-        Wildcard1.jl5;
+        Wildcard1.jl5 (Post, "Xlint:unchecked");
         wildcard2.jl5 (Semantic), (Semantic), (Semantic);
         wildcard2a.jl5;
-        wildcard3.jl5;
+        wildcard3.jl5 (Post, "Xlint:unchecked");
         wildcard4.jl5 (Semantic, "cannot be called"), (Semantic, "cannot be called"), (Semantic, "does not match");
         wildcard4a.jl5;
         wildcard5.jl5 (Semantic, "cannot be called"), (Semantic, "cannot be called") , (Semantic, "does not match");
@@ -861,19 +860,19 @@ polyglot.ext.jl5.JL5ExtensionInfo "-d out -classpath java-out -removeJava5isms -
         wildcard9.jl5; # TODO
         wildcard10.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match");
         wildcard11.jl5 (Semantic, "capture"), (Semantic, "capture"), (Semantic, "does not match"), (Semantic, "does not match"), (Semantic, "does not match");
-        wildcard12a.jl5(Semantic);
-        wildcard12b.jl5(Semantic);
-        wildcard12c.jl5(Semantic);
-        wildcard12d.jl5(Semantic);
-        wildcard12e.jl5;
+        wildcard12a.jl5 (Semantic);
+        wildcard12b.jl5 (Semantic);
+        wildcard12c.jl5 (Semantic);
+        wildcard12d.jl5 (Semantic);
+        wildcard12e.jl5 (Post, "Xlint:unchecked");
         wildcard13a.jl5 (Semantic);
         wildcard13b.jl5 (Semantic);
         wildcard13c.jl5 (Semantic);
-        wildcard13d.jl5;
+        wildcard13d.jl5 (Post, "Xlint:unchecked");
         wildcard14a.jl5 (Semantic);
         wildcard14b.jl5 (Semantic);
         wildcard14c.jl5 (Semantic);
-        wildcard14d.jl5 ;
+        wildcard14d.jl5 (Post, "Xlint:unchecked");
         wildcard15.jl5 (Semantic),(Semantic);
         wildcard16.jl5 (Semantic, "Cannot assign long to");
         wildcard17.jl5 (Semantic),(Semantic),(Semantic);

--- a/testsjl7/.gitignore
+++ b/testsjl7/.gitignore
@@ -1,5 +1,6 @@
 out
 pthScript.results
 pthOutput*
+java-out
 /pthScript-JL.results
 /pthScript-JL5.results

--- a/testsjl7/java-src/.gitignore
+++ b/testsjl7/java-src/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl7/packA/.gitignore
+++ b/testsjl7/packA/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl7/packB/.gitignore
+++ b/testsjl7/packB/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl7/package1/.gitignore
+++ b/testsjl7/package1/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class

--- a/testsjl7/package2/.gitignore
+++ b/testsjl7/package2/.gitignore
@@ -1,0 +1,2 @@
+*.java
+*.class


### PR DESCRIPTION
The remaining ones seem to be not fixable without deep look into the type system, but there are some easy fixes that solve most of the problem:

## Explictly add expected `Xlint:unchecked` to pthScript

Since we can no longer rely on `-source 1.4` and `-target 1.4` since Java 9, we must explicitly annotate expected xlint warnings in order to pass the tests.

## Create empty directories for tests

Some directory holding copied over files do not exist, which causes the `pth` script to crash