### PR TITLE
Fix MethodDecl08 tests

### DIFF
--- a/src/polyglot/ext/jl5/types/JL5MethodInstance_c.java
+++ b/src/polyglot/ext/jl5/types/JL5MethodInstance_c.java
@@ -121,7 +121,7 @@ public class JL5MethodInstance_c extends MethodInstance_c implements JL5MethodIn
                         : Collections.singleton(rt.superType());
         for (Type superType : supers) {
             if (superType != null && superType.isReference()) {
-                l.addAll(implementedImpl(superType.toReference()));
+                l.addAll(implementedImplAux(superType.toReference()));
             }
         }
 

--- a/tests/pthScript-wip
+++ b/tests/pthScript-wip
@@ -37,11 +37,3 @@ javac "-d java-out -cp ." {
 polyglot.frontend.JLExtensionInfo "-assert -d out -cp java-out" {
     Assert06.jl;
 }
-
-polyglot.ext.jl5.JL5ExtensionInfo "-sx jl -d out-jl5 -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
-    MethodDecl08a.jl MethodDecl08b.jl (Semantic, "hidden method is not static");
-}
-
-polyglot.ext.jl7.JL7ExtensionInfo "-sx jl -d out-jl7 -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
-    MethodDecl08a.jl MethodDecl08b.jl (Semantic, "hidden method is not static");
-}

--- a/testsjl5/pthScript-JL
+++ b/testsjl5/pthScript-JL
@@ -220,6 +220,7 @@ polyglot.ext.jl5.JL5ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         MethodDecl05.jl (Semantic, "incompatible return type");
         MethodDecl06.jl (Semantic, "throw set .* not a subset of the overridden method");
         MethodDecl07.jl (Semantic, "overridden method is final");
+        MethodDecl08a.jl MethodDecl08b.jl (Semantic, "hidden method is not static");
         MethodDecl09.jl;
         Narrowing.jl ;
         New01a.jl New01b.jl;

--- a/testsjl7/pthScript-JL
+++ b/testsjl7/pthScript-JL
@@ -220,6 +220,7 @@ polyglot.ext.jl7.JL7ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         MethodDecl05.jl (Semantic, "incompatible return type");
         MethodDecl06.jl (Semantic, "throw set .* not a subset of the overridden method");
         MethodDecl07.jl (Semantic, "overridden method is final");
+        MethodDecl08a.jl MethodDecl08b.jl (Semantic, "hidden method is not static");
         MethodDecl09.jl;
         Narrowing.jl ;
         New01a.jl New01b.jl;


### PR DESCRIPTION
`implementedImplAux` must always call `implementedImplAux` recursively, so that we can get all transitive super classes without the accessible filter.