### PR TITLE
Parse subset of lambda grammar that do not introduce parsing ambiguities

### DIFF
--- a/src/polyglot/ext/jl8/JL8ExtensionInfo.java
+++ b/src/polyglot/ext/jl8/JL8ExtensionInfo.java
@@ -40,7 +40,6 @@ import polyglot.ext.jl8.types.JL8TypeSystem_c;
 import polyglot.frontend.CupParser;
 import polyglot.frontend.Parser;
 import polyglot.frontend.Source;
-import polyglot.lex.Lexer;
 import polyglot.main.Version;
 import polyglot.types.TypeSystem;
 import polyglot.util.ErrorQueue;
@@ -67,7 +66,9 @@ public class JL8ExtensionInfo extends JL7ExtensionInfo {
 
     @Override
     protected NodeFactory createNodeFactory() {
-        return new JL8NodeFactory_c(JL8Lang_c.instance, new JL8ExtFactory_c(new JL7ExtFactory_c(new JL5ExtFactory_c())));
+        return new JL8NodeFactory_c(
+                JL8Lang_c.instance,
+                new JL8ExtFactory_c(new JL7ExtFactory_c(new JL5ExtFactory_c())));
     }
 
     @Override

--- a/src/polyglot/ext/jl8/ast/JL8Ext.java
+++ b/src/polyglot/ext/jl8/ast/JL8Ext.java
@@ -38,8 +38,9 @@ public class JL8Ext extends Ext_c {
             e = e.ext();
         }
         if (e == null) {
-            throw new InternalCompilerError("No jl8 extension object for node "
-                    + n + " (" + n.getClass() + ")", n.position());
+            throw new InternalCompilerError(
+                    "No jl8 extension object for node " + n + " (" + n.getClass() + ")",
+                    n.position());
         }
         return (JL8Ext) e;
     }

--- a/src/polyglot/ext/jl8/ast/JL8Lang_c.java
+++ b/src/polyglot/ext/jl8/ast/JL8Lang_c.java
@@ -36,15 +36,13 @@ public class JL8Lang_c extends J7Lang_c implements JL8Lang {
         while (n != null) {
             Lang lang = n.lang();
             if (lang instanceof JL8Lang) return (JL8Lang) lang;
-            if (n instanceof Ext)
-                n = ((Ext) n).pred();
+            if (n instanceof Ext) n = ((Ext) n).pred();
             else return null;
         }
         throw new InternalCompilerError("Impossible to reach");
     }
 
-    protected JL8Lang_c() {
-    }
+    protected JL8Lang_c() {}
 
     protected static JL8Ext jl8Ext(Node n) {
         return JL8Ext.ext(n);

--- a/src/polyglot/ext/jl8/parse/jl8.flex
+++ b/src/polyglot/ext/jl8/parse/jl8.flex
@@ -423,6 +423,7 @@ OctalEscape = \\ [0-7]
     "<<"   { return op(sym.LSHIFT);     }
     ">>"   { return op(sym.RSHIFT);     }
     ">>>"  { return op(sym.URSHIFT);    }
+    "->"   { return op(sym.ARROW);      }
     "+="   { return op(sym.PLUSEQ);     }
     "-="   { return op(sym.MINUSEQ);    }
     "*="   { return op(sym.MULTEQ);     }

--- a/src/polyglot/ext/jl8/parse/jl8.ppg
+++ b/src/polyglot/ext/jl8/parse/jl8.ppg
@@ -52,22 +52,24 @@ nonterminal inferred_formal_parameter_list;
 nonterminal lambda_body;
 
 terminal token ARROW;
+terminal token RPAREN_ARROW;
 
 start with goal;
 
-extend expression ::= lambda_expression;
+extend expression_nn ::= lambda_expression;
 
 lambda_expression ::=
-      IDENTIFIER ARROW lambda_body
+      simple_name ARROW lambda_body
     | LPAREN RPAREN ARROW lambda_body
-;
+    | LPAREN inferred_formal_parameter_list RPAREN_ARROW lambda_body
+    ;
 
 inferred_formal_parameter_list ::=
-      IDENTIFIER
-    | inferred_formal_parameter_list COMMA IDENTIFIER
-;
+      simple_name
+    | inferred_formal_parameter_list COMMA simple_name
+    ;
 
 lambda_body ::=
       expression
     | block
-;
+    ;

--- a/src/polyglot/ext/jl8/parse/jl8.ppg
+++ b/src/polyglot/ext/jl8/parse/jl8.ppg
@@ -47,4 +47,27 @@ parser Grm extends polyglot.ext.jl7.parse.Grm  {:
 
 :};
 
+nonterminal lambda_expression;
+nonterminal inferred_formal_parameter_list;
+nonterminal lambda_body;
+
+terminal token ARROW;
+
 start with goal;
+
+extend expression ::= lambda_expression;
+
+lambda_expression ::=
+      IDENTIFIER ARROW lambda_body
+    | LPAREN RPAREN ARROW lambda_body
+;
+
+inferred_formal_parameter_list ::=
+      IDENTIFIER
+    | inferred_formal_parameter_list COMMA IDENTIFIER
+;
+
+lambda_body ::=
+      expression
+    | block
+;

--- a/src/polyglot/filemanager/ExtFileManager.java
+++ b/src/polyglot/filemanager/ExtFileManager.java
@@ -138,9 +138,13 @@ public class ExtFileManager extends ForwardingJavaFileManager<StandardJavaFileMa
     }
 
     private static void setupPackageCacheForBuiltinPackages() {
-        File builtinClasspathFile = new File(
-                System.getProperty("java.home") +
-                        separatorChar + "lib" + separatorChar + "classlist");
+        File builtinClasspathFile =
+                new File(
+                        System.getProperty("java.home")
+                                + separatorChar
+                                + "lib"
+                                + separatorChar
+                                + "classlist");
         if (builtinClasspathFile.exists()) {
             try (BufferedReader reader = new BufferedReader(new FileReader(builtinClasspathFile))) {
                 while (true) {
@@ -153,7 +157,8 @@ public class ExtFileManager extends ForwardingJavaFileManager<StandardJavaFileMa
                         index = line.indexOf('/', index + 1);
                     }
                 }
-            } catch (IOException e) { }
+            } catch (IOException e) {
+            }
         }
     }
 

--- a/tools/format-check
+++ b/tools/format-check
@@ -4,6 +4,6 @@
 
 java -jar lib/google-java-format.jar \
   --aosp --skip-sorting-imports --skip-javadoc-formatting \
-  --dry-run \
+  --dry-run --set-exit-if-changed \
   $(git ls-tree -r HEAD --name-only src | grep -E '.*\.java') \
   $(git ls-tree -r HEAD --name-only tools | grep -E '.*\.java') 2> /dev/null


### PR DESCRIPTION
Fully lambda expression grammar introduces a lot of ambiguity to the grammar without simple fix. [As stated by the Java language spec itself](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.27):

> The syntax has some parsing challenges. The Java programming language has always required arbitrary lookahead to distinguish between types and expressions after a '(' token: what follows may be a cast or a parenthesized expression. This was made worse when generics reused the binary operators '<' and '>' in types. Lambda expressions introduce a new possibility: the tokens following '(' may describe a type, an expression, or a lambda parameter list. Some tokens immediately indicate a parameter list (annotations, final); in other cases there are certain patterns that must be interpreted as parameter lists (two names in a row, a ',' not nested inside of '<' and '>'); and sometimes, the decision cannot be made until a '->' is encountered after a ')'. The simplest way to think of how this might be efficiently parsed is with a state machine: each state represents a subset of possible interpretations (type, expression, or parameters), and when the machine transitions to a state in which the set is a singleton, the parser knows which case it is. This does not map very elegantly to a fixed-lookahead grammar, however.

This PR extends the parser to parse a subset of lambda expressions syntax, so that we can use this to start type checking work first.