### PR TITLE
Add `FunctionInterfaceAnonymousClass` test case for JL8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,6 @@ jobs:
       - name: Run JL7 Tests
         run: ../bin/pth -ec pthScript-JL7
         working-directory: ./testsjl8
+      - name: Run JL8 Tests
+        run: ../bin/pth -ec pthScript
+        working-directory: ./testsjl8

--- a/testsjl8/FunctionInterfaceAnonynousClass.jl8
+++ b/testsjl8/FunctionInterfaceAnonynousClass.jl8
@@ -1,0 +1,13 @@
+import java.util.function.Function;
+
+public class FunctionInterfaceAnonymousClass {
+    void test() {
+        Function<Integer, Integer> negation = new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer integer) {
+                return -integer;
+            }
+        };
+        negation.apply(3);
+    }
+}

--- a/testsjl8/pthScript
+++ b/testsjl8/pthScript
@@ -1,0 +1,36 @@
+# pth test script
+#
+# This file is a test script for pth (Polyglot Test Harness). It
+# conforms to the following grammar.
+#
+#      ScriptFile   ::= CompilerTest+
+#      CompilerTest ::= ExtClassName ["CmdLineArgs"] { FileTest [; FileTest]* }
+#                    |  javac ["CmdLineArgs"] { FileTestNoFailure [; FileTestNoFailure]* }
+#      FileTest     ::= Filenames [Description] [FailureSet]
+#      FileTestNoFailure ::= Filenames [Description]
+#      Filenames    ::= Filename [Filename]*
+#      Description  ::= LitString
+#      FailureSet   ::= Failure [, Failure]*
+#      Failure      ::= ( ErrorKind )
+#                    |  ( ErrorKind, "RegExp" )
+#                    |  ( "RegExp" )
+#                    |  ( )
+#      ErrorKind    :   one of, or a unique prefix of one of the following
+#                       strings: "Warning", "Internal Error", "I/O Error",
+#                       "Lexical Error", "Syntax Error", "Semantic Error"
+#                       or "Post-compiler Error".
+#      Filename     :   the name of a file. Is interpreted from the
+#                       directory where pth is run.
+#      LitString    :   a literal string, enclosed in quotes.
+#      RegExp       :   a regular expression, as in java.util.regex;
+#                       is always enclosed in quotes.
+#      CmdLineArgs  :   additional command line args for the Polyglot
+#                       compiler; is always enclosed in quotes.
+
+# Compile some java classes first
+#javac "-d java-out -cp ." {
+#}
+
+polyglot.ext.jl8.JL8ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
+	FunctionInterfaceAnonynousClass.jl8;
+}


### PR DESCRIPTION
This doesn't have anything to do with lambdas yet, but it uses the `Function` interface (which is >=java8 only) and it uses the codepath that activates the JL8 extension. This allows us to do some debugging work on the functional interface on real code.