### PR TITLE
Type checking lambda expressions

### DIFF
--- a/src/polyglot/ext/jl8/ast/Lambda.java
+++ b/src/polyglot/ext/jl8/ast/Lambda.java
@@ -2,10 +2,14 @@ package polyglot.ext.jl8.ast;
 
 import java.util.List;
 import polyglot.ast.Block;
+import polyglot.ast.CodeNode;
 import polyglot.ast.Expr;
 import polyglot.ast.Formal;
+import polyglot.ext.jl8.types.JL8TypeSystem;
+import polyglot.types.SemanticException;
+import polyglot.types.Type;
 
-public interface Lambda extends Expr {
+public interface Lambda extends Expr, CodeNode {
     List<Formal> formals();
 
     Lambda formals(List<Formal> formals);
@@ -13,4 +17,6 @@ public interface Lambda extends Expr {
     Block block();
 
     Lambda block(Block block);
+
+    void setTargetType(Type targetType, JL8TypeSystem typeSystem) throws SemanticException;
 }

--- a/src/polyglot/ext/jl8/types/JL8TypeSystem.java
+++ b/src/polyglot/ext/jl8/types/JL8TypeSystem.java
@@ -25,8 +25,11 @@
  ******************************************************************************/
 package polyglot.ext.jl8.types;
 
+import java.util.List;
 import polyglot.ext.jl7.types.JL7TypeSystem;
+import polyglot.types.MethodInstance;
+import polyglot.types.ReferenceType;
 
 public interface JL8TypeSystem extends JL7TypeSystem {
-    // TODO: declare any new methods needed
+    List<MethodInstance> nonObjectPublicAbstractMethods(ReferenceType referenceType);
 }

--- a/src/polyglot/ext/jl8/types/JL8TypeSystem_c.java
+++ b/src/polyglot/ext/jl8/types/JL8TypeSystem_c.java
@@ -25,9 +25,41 @@
  ******************************************************************************/
 package polyglot.ext.jl8.types;
 
+import java.util.ArrayList;
+import java.util.List;
 import polyglot.ext.jl7.types.JL7TypeSystem_c;
+import polyglot.types.Flags;
+import polyglot.types.MethodInstance;
+import polyglot.types.ReferenceType;
 
 public class JL8TypeSystem_c extends JL7TypeSystem_c implements JL8TypeSystem {
-    // TODO: implement new methods in jl8TypeSystem.
-    // TODO: override methods as needed from TypeSystem_c.
+    @Override
+    public List<MethodInstance> nonObjectPublicAbstractMethods(ReferenceType referenceType) {
+        List<MethodInstance> objectPublicMethods = this.objectPublicMethods();
+        List<MethodInstance> nonObjectPublicAbstractMethods = new ArrayList<>();
+        for (MethodInstance m : referenceType.methods()) {
+            Flags flags = m.flags();
+            if (flags.isPublic() && flags.isAbstract()) {
+                boolean isObjectMethod = false;
+                for (MethodInstance objectMethod : objectPublicMethods) {
+                    if (m.isSameMethod(objectMethod)) {
+                        isObjectMethod = true;
+                        break;
+                    }
+                }
+                if (!isObjectMethod) nonObjectPublicAbstractMethods.add(m);
+            }
+        }
+        return nonObjectPublicAbstractMethods;
+    }
+
+    private List<MethodInstance> objectPublicMethods() {
+        List<MethodInstance> objectMethods = new ArrayList<>();
+        for (MethodInstance i : Object().methods()) {
+            if (i.flags().isPublic()) {
+                objectMethods.add(i);
+            }
+        }
+        return objectMethods;
+    }
 }


### PR DESCRIPTION
Type check is now passing on this simple example:

```java
import java.util.function.Consumer;

public class SimpleLambda01 {
    void test() {
        Consumer<Integer> negation = (i) -> {};
        negation.accept(3);
    }
}
```

We are not using the type information from the target type yet, but now it's been correctly passed and processed.

We still have some issues with control flow. In particular, I'm still trying to convince the dataflow analyzer that the `return` inside lambda belongs to a closure and shouldn't make other parts unreachable.