### PR TITLE
Full parsing support for lambda expressions

### DIFF
--- a/src/polyglot/ext/jl5/ast/AmbTypeInstantiation.java
+++ b/src/polyglot/ext/jl5/ast/AmbTypeInstantiation.java
@@ -117,19 +117,6 @@ public class AmbTypeInstantiation extends TypeNode_c implements Ambiguous {
         JL5ParsedClassType pct = handleBase(typeMap);
 
         Type baseType = base.type();
-        //        System.err.println("Base type is " + base);
-        //        System.err.println("typeArguments is " + typeArguments);
-        //        if (baseType instanceof JL5SubstClassType) {
-        //            System.err.println("  " + this.position);
-        //            System.err.println("    base type of " + this + " is " + base.type()+ " " +
-        // base.type().getClass());
-        //            System.err.println("   base type base is " +
-        // ((JL5SubstClassType)baseType).base());
-        //            System.err.println("   base type instantiation is " +
-        // ((JL5SubstClassType)baseType).subst() + "  " +
-        // ((JL5SubstClassType)baseType).subst().getClass());
-        //            System.err.println("   type args are is " + this.typeArguments);
-        //        }
 
         if (pct.pclass() == null || pct.pclass().formals().isEmpty()) {
             // The base class has no formals.
@@ -156,7 +143,6 @@ public class AmbTypeInstantiation extends TypeNode_c implements Ambiguous {
             typeMap.put(formals.get(i), t);
         }
 
-        //        System.err.println("Instantiating " + pct + " with " + typeMap);
         JL5TypeSystem ts = (JL5TypeSystem) sc.typeSystem();
         Type instantiated = ts.subst(pct, typeMap);
         return sc.nodeFactory().CanonicalTypeNode(position, instantiated);

--- a/src/polyglot/ext/jl5/ast/ExtendedFor_c.java
+++ b/src/polyglot/ext/jl5/ast/ExtendedFor_c.java
@@ -142,10 +142,6 @@ public class ExtendedFor_c extends Loop_c implements ExtendedFor {
         Position position = n.position();
         // Check that the expr is an array or of type Iterable
         Type t = expr.type();
-        //        System.err.println(" t is a " + t.getClass());
-        //        System.err.println("    t is a " + ts.allAncestorsOf((ReferenceType) t));
-        //        System.err.println("    erasure(t) is " + ts.erasureType(t));
-        //        System.err.println("    iterable is a " + ts.Iterable().getClass());
         if (!expr.type().isArray()
                 && !t.isSubtype(ts.rawClass((JL5ParsedClassType) ts.Iterable()))) {
             throw new SemanticException(

--- a/src/polyglot/ext/jl5/ast/JL5CallExt.java
+++ b/src/polyglot/ext/jl5/ast/JL5CallExt.java
@@ -179,21 +179,6 @@ public class JL5CallExt extends JL5ProcedureCallExt implements CallOps {
                                 ext.expectedReturnType(),
                                 !(n.target() instanceof Special));
 
-        //        System.err.println("\nJL5Call_c.typeCheck targettype is " + targetType);
-        //        System.err.println("  JL5Call_c.typeCheck target is " + this.target);
-        //        System.err.println("  JL5Call_c.typeCheck target type is "
-        //                + this.target.type());
-        //        if (this.target.type().isClass()) {
-        //            System.err.println("  JL5Call_c.typeCheck target type super is "
-        //                    + this.target.type().toClass().superType());
-        //        }
-        //        System.err.println("  JL5Call_c.expectedReturnType is "
-        //                + this.expectedReturnType);
-        //        System.err.println("  JL5Call_c.typeCheck arg types is " + argTypes);
-        //        System.err.println("  JL5Call_c.typeCheck mi is " + mi
-        //                + " return type is " + mi.returnType().getClass());
-        //        System.err.println("  JL5Call_c.typeCheck mi is " + mi
-        //                + " container is " + mi.container().getClass());
         if (staticContext && !mi.flags().isStatic()) {
             throw new SemanticException(
                     "Cannot call non-static method "
@@ -232,7 +217,6 @@ public class JL5CallExt extends JL5ProcedureCallExt implements CallOps {
                             Collections.singletonList(wt));
             n = (Call) n.type(instClass);
         }
-        //        System.err.println("JL5Call_c: " + this + " got mi " + mi);
 
         return n;
     }

--- a/src/polyglot/ext/jl5/ast/ParamTypeNode_c.java
+++ b/src/polyglot/ext/jl5/ast/ParamTypeNode_c.java
@@ -168,16 +168,10 @@ public class ParamTypeNode_c extends TypeNode_c implements ParamTypeNode {
                 // not disambiguated yet
                 ambiguous = true;
             }
-            //			if (!tn.type().isReference()) {
-            //			    throw new SemanticException("Cannot instantiate a type parameter with type " +
-            // tn.type());
-            //			}
             typeList.add(tn.type());
         }
         if (!ambiguous) {
             TypeVariable tv = (TypeVariable) n.type();
-            //		System.err.println("paramtypenode_c : dismab and setting bounds of " + tv + " to " +
-            // typeList);
             List<ReferenceType> refTypeList = new ArrayList<>();
             for (Type t : typeList) refTypeList.add((ReferenceType) t);
             tv.setUpperBound(ts.intersectionType(n.position(), refTypeList));

--- a/src/polyglot/ext/jl5/types/JL5ConstructorInstance_c.java
+++ b/src/polyglot/ext/jl5/types/JL5ConstructorInstance_c.java
@@ -71,8 +71,6 @@ public class JL5ConstructorInstance_c extends ConstructorInstance_c
     public boolean callValidImpl(List<? extends Type> argTypes) {
         List<Type> myFormalTypes = formalTypes;
 
-        // System.err.println("JL5MethodInstance_c callValid Impl " + this +
-        // " called with " +argTypes);
         // now compare myFormalTypes to argTypes
         if (!isVariableArity() && argTypes.size() != myFormalTypes.size()) {
             return false;
@@ -114,13 +112,9 @@ public class JL5ConstructorInstance_c extends ConstructorInstance_c
                 // or the array type.
                 ArrayType arr = (ArrayType) myFormalTypes.get(myFormalTypes.size() - 1);
                 if (!ts.isImplicitCastValid(actual, arr)) {
-                    // System.err.println("     3: failed " + actual +
-                    // " to " +formal + " and " + actual + " to " + arr);
                     return false;
                 }
             } else {
-                // System.err.println("     4: failed " + actual + " to "
-                // +formal);
                 return false;
             }
         }

--- a/src/polyglot/ext/jl5/types/JL5MethodInstance_c.java
+++ b/src/polyglot/ext/jl5/types/JL5MethodInstance_c.java
@@ -304,16 +304,12 @@ public class JL5MethodInstance_c extends MethodInstance_c implements JL5MethodIn
     public boolean callValidImpl(List<? extends Type> argTypes) {
         List<Type> myFormalTypes = formalTypes;
 
-        //         System.err.println("JL5MethodInstance_c callValid Impl " + this +" called with "
-        // +argTypes);
         // now compare myFormalTypes to argTypes
         if (!isVariableArity() && argTypes.size() != myFormalTypes.size()) {
-            //            System.err.println("     1");
             return false;
         }
         if (isVariableArity() && argTypes.size() < myFormalTypes.size() - 1) {
             // the last (variable) argument can consume 0 or more of the actual arguments.
-            //            System.err.println("     2");
             return false;
         }
 
@@ -349,13 +345,9 @@ public class JL5MethodInstance_c extends MethodInstance_c implements JL5MethodIn
                 // or the array type.
                 ArrayType arr = (ArrayType) myFormalTypes.get(myFormalTypes.size() - 1);
                 if (!ts.isImplicitCastValid(actual, arr)) {
-                    //                         System.err.println("     3: failed " + actual + " to
-                    // " +formal + " and " + actual + " to " + arr);
                     return false;
                 }
             } else {
-                //                     System.err.println("     4: failed " + actual + " to "
-                // +formal);
                 return false;
             }
         }

--- a/src/polyglot/ext/jl5/types/JL5SubstClassType_c.java
+++ b/src/polyglot/ext/jl5/types/JL5SubstClassType_c.java
@@ -204,16 +204,6 @@ public class JL5SubstClassType_c extends SubstClassType_c<TypeVariable, Referenc
 
         JL5TypeSystem ts = (JL5TypeSystem) this.ts;
 
-        //        System.err.println("jl5substclasstype: descends from " + this + " <: " +
-        // ancestor);
-        //        System.err.println("    superclass of  " + this + " is " + this.superType());
-        //        System.err.println("    base class of  " + this + " is " + this.base());
-        //        System.err.println("       super of " + this.base() + " is " +
-        // this.base().superType());
-        //        System.err.println("    subst  of  " + this + " is " + this.subst());
-        //        System.err.println("   applying subst " + subst.substType(this.base()) + " super "
-        // + ((ReferenceType)subst.substType(this.base())).superType());
-
         // See JLS 3rd ed 4.10.2
         if (hasWildCardArg()) {
             Type captured;
@@ -240,17 +230,14 @@ public class JL5SubstClassType_c extends SubstClassType_c<TypeVariable, Referenc
         }
         if (ancestor instanceof JL5SubstClassType_c) {
             JL5SubstClassType_c anc = (JL5SubstClassType_c) ancestor;
-            //            System.err.println("      C");
             if (this.base.equals(anc.base)) {
-                //                System.err.println("      D");
                 // same base. check the params
                 // go through each type variable, and check containment
                 boolean allContained = true;
                 for (TypeVariable tv : ts.classAndEnclosingTypeVariables(base())) {
                     Type ti = this.subst.substType(tv);
                     Type si = anc.subst.substType(tv);
-                    //                    System.err.println("      E " + ti + " contained in "+si+"
-                    // ? " + ts.isContained(ti, si));
+
                     if (!ts.isContained(ti, si)) {
                         allContained = false;
                         break;

--- a/src/polyglot/ext/jl5/types/JL5TypeSystem_c.java
+++ b/src/polyglot/ext/jl5/types/JL5TypeSystem_c.java
@@ -471,7 +471,6 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
 
     @Override
     public TypeVariable typeVariable(Position pos, String name, ReferenceType upperBound) {
-        //        System.err.println("JL5TS_c typevar created " + name + " " + bounds);
         return new TypeVariable_c(this, pos, name, upperBound);
     }
 
@@ -647,12 +646,8 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
         LinkedList<Type> typeQueue = new LinkedList<>();
         typeQueue.addLast(container);
 
-        //        System.err.println("JL5TS: findAcceptableMethods for " + name + " in " +
-        // container);
         while (!typeQueue.isEmpty()) {
             Type type = typeQueue.remove();
-
-            //            System.err.println("   looking at type " + type + " " + type.getClass());
             // Make sure each type is considered only once
             if (visitedTypes.contains(type)) continue;
             visitedTypes.add(type);
@@ -682,7 +677,6 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
 
                 // Method name must match
                 if (!mi.name().equals(name)) continue;
-                //                System.err.println("      checking " + mi);
 
                 JL5MethodInstance substMi =
                         methodCallValid(mi, name, argTypes, actualTypeArgs, expectedReturnType);
@@ -790,13 +784,6 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
             phase3methods.removeAll(mi.overrides());
         }
 
-        //        System.err.println("JL5ts_c: acceptable methods for " + name + argTypes
-        //                + " is " + phase1methods);
-        //        System.err.println("              " + phase2methods);
-        //        System.err.println("              " + phase3methods);
-        //        System.err.println("        phase1overridden is    " + phase1overridden);
-        //        System.err.println("        phase2overridden is    " + phase2overridden);
-        //        System.err.println("        phase3overridden is    " + phase3overridden);
         if (!phase1methods.isEmpty()) return phase1methods;
         if (!phase2methods.isEmpty()) return phase2methods;
         if (!phase3methods.isEmpty()) return phase3methods;
@@ -1363,16 +1350,12 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
 
     @Override
     public boolean descendsFrom(Type child, Type ancestor) {
-        //        System.err.println("jl5TS_C: descends from: " + child + " descended from " +
-        // ancestor);
         boolean b = super.descendsFrom(child, ancestor);
         if (b) return true;
-        //        System.err.println("   : descends from 0");
         if (ancestor instanceof TypeVariable) {
             TypeVariable tv = (TypeVariable) ancestor;
             // See JLS 3rd ed 4.10.2: type variable is a direct supertype of its lowerbound.
             if (tv.hasLowerBound()) {
-                //                System.err.println("   : descends from 1");
                 return isSubtype(child, tv.lowerBound());
             }
         }
@@ -1380,7 +1363,6 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
             WildCardType w = (WildCardType) ancestor;
             // See JLS 3rd ed 4.10.2: type variable is a direct supertype of its lowerbound.
             if (w.hasLowerBound()) {
-                //                System.err.println("   : descends from 2");
                 return isSubtype(child, w.lowerBound());
             }
         }
@@ -1391,7 +1373,6 @@ public class JL5TypeSystem_c extends ParamTypeSystem_c<TypeVariable, ReferenceTy
                 if (descendsFrom(child, rt)) return true;
             }
         }
-        //        System.err.println("   : descends from 3");
         return false;
     }
 

--- a/src/polyglot/ext/jl5/types/RawClass_c.java
+++ b/src/polyglot/ext/jl5/types/RawClass_c.java
@@ -222,17 +222,7 @@ public class RawClass_c extends JL5ClassType_c implements RawClass {
 
     @Override
     public boolean descendsFromImpl(Type ancestor) {
-        //        System.err.println("   Raw class " + this + " descends from " + ancestor + " ?
-        // interfaces is " + this.interfaces() + "  ::: " + super.descendsFromImpl(ancestor));
-        //        System.err.println("    base interfaces are "  + this.base.interfaces());
-        if (super.descendsFromImpl(ancestor)) {
-            return true;
-        }
-        //        Type ra = ((JL5TypeSystem)ts).toRawType(ancestor);
-        //        if (!ra.equals(ancestor)) {
-        //            return ts.isSubtype(this, ra);
-        //        }
-        return false;
+        return super.descendsFromImpl(ancestor);
     }
 
     @Override

--- a/src/polyglot/ext/jl5/types/inference/InferenceSolver_c.java
+++ b/src/polyglot/ext/jl5/types/inference/InferenceSolver_c.java
@@ -92,11 +92,6 @@ public class InferenceSolver_c implements InferenceSolver {
         List<EqualConstraint> equals = new ArrayList<>();
         List<SubTypeConstraint> subs = new ArrayList<>();
         List<SuperTypeConstraint> supers = new ArrayList<>();
-        //        System.err.println("**** inference solver:");
-        //        System.err.println("      constraints : " + constraints);
-        //        System.err.println("      use subs? : " + useSubtypeConstraints
-        //                + "   use sups? : " + useSupertypeConstraints);
-        //        System.err.println("      variables : " + typeVariablesToSolve());
 
         while (!constraints.isEmpty()) {
             Constraint head = constraints.remove(0);
@@ -116,9 +111,6 @@ public class InferenceSolver_c implements InferenceSolver {
                 }
             }
         }
-        //        System.err.println("      a equals : " + equals);
-        //        System.err.println("      a subs   : " + subs);
-        //        System.err.println("      a supers : " + supers);
 
         Comparator<Constraint> comp =
                 new Comparator<Constraint>() {
@@ -131,10 +123,6 @@ public class InferenceSolver_c implements InferenceSolver {
         Collections.sort(equals, comp);
         Collections.sort(subs, comp);
         Collections.sort(supers, comp);
-
-        //        System.err.println("      equals : " + equals);
-        //        System.err.println("      subs   : " + subs);
-        //        System.err.println("      supers : " + supers);
 
         Type[] solution = new Type[typeVariablesToSolve().size()];
         for (EqualConstraint eq : equals) {
@@ -174,8 +162,6 @@ public class InferenceSolver_c implements InferenceSolver {
                 }
             }
         }
-
-        //        System.err.println("      Solution : " + Arrays.asList(solution));
 
         return solution;
     }
@@ -256,8 +242,6 @@ public class InferenceSolver_c implements InferenceSolver {
                 cons.add(new SuperConversionConstraint(expectedReturnType, returnType, this));
                 Type[] betterSolution = this.solve(cons, true, false);
                 if (betterSolution != null) {
-                    //                    System.err.println("Found a better solution: " +
-                    // Arrays.asList(betterSolution));
                     solution = betterSolution;
                 }
             }

--- a/src/polyglot/ext/jl5/types/reflect/JL5ClassFileLazyClassInitializer.java
+++ b/src/polyglot/ext/jl5/types/reflect/JL5ClassFileLazyClassInitializer.java
@@ -103,12 +103,8 @@ public class JL5ClassFileLazyClassInitializer extends ClassFileLazyClassInitiali
         // Create the ClassType.
         JL5ParsedClassType ct = (JL5ParsedClassType) super.createType();
 
-        // System.err.println("Added " + name + " " + ct +
-        // " to the system resolver.");
-
         JL5Signature signature = ((JL5ClassFile) clazz).getSignature();
         // Load the class signature
-        // System.err.println("    signature == null? " + (signature == null));
         if (signature != null) {
             MuPClass<TypeVariable, ReferenceType> pc =
                     ((JL5TypeSystem) ts).mutablePClass(ct.position());
@@ -131,32 +127,6 @@ public class JL5ClassFileLazyClassInitializer extends ClassFileLazyClassInitiali
 
             ct.superType(signature.classSignature.superType());
             ct.setInterfaces(signature.classSignature.interfaces());
-
-            /*
-             * System.err.println("Class signature type for " + name);
-             * System.err.println("    interfaces " +
-             * signature.classSignature.interfaces());
-             * System.err.println("    supertype " +
-             * signature.classSignature.superType());
-             * System.err.println("           " +
-             * signature.classSignature.superType().getClass());
-             * System.err.println("    typevars " +
-             * signature.classSignature.typeVars());
-             * System.err.println("  type vars " +
-             * signature.classSignature.typeVars() + " for class " + name);
-             *
-             * System.err.println("Class signature type for " + name);
-             * System.err.println("          " + ct.getClass());
-             * System.err.println("    interfaces " + ct.interfaces());
-             * System.err.println("    supertype " + ct.superType());
-             * System.err.println("           " + ct.superType().getClass());
-             * System.err.println("    typevars " + ct.typeVariables());
-             * System.err.println("  type vars " + ct.typeVariables() +
-             * " for class " + name);
-             */
-        } else {
-            // System.err.println("Class signature type for " + name +
-            // ": null signature");
         }
 
         return ct;
@@ -195,15 +165,6 @@ public class JL5ClassFileLazyClassInitializer extends ClassFileLazyClassInitiali
                 excTypes = tt;
             }
 
-            /*
-             * System.err.println("Method signature type for " + name);
-             * System.err.println("    returnType " +jl5RetType);
-             * System.err.println("    formalTypes "
-             * +signature.methodSignature.formalTypes);
-             * System.err.println("    typevars "
-             * +signature.methodSignature.typeVars);
-             * System.err.println("    throwTypes " +excTypes);
-             */
             mi =
                     ts.methodInstance(
                             ct.position(),
@@ -217,9 +178,6 @@ public class JL5ClassFileLazyClassInitializer extends ClassFileLazyClassInitiali
                             excTypes,
                             signature.methodSignature.typeVars());
         } else {
-            // System.err.println("Method signature type for " + name +
-            // " returnType: null signature");
-
             if (type.charAt(0) != '(') {
                 throw new ClassFormatError("Bad method type descriptor.");
             }

--- a/src/polyglot/ext/jl5/types/reflect/JL5Method.java
+++ b/src/polyglot/ext/jl5/types/reflect/JL5Method.java
@@ -47,7 +47,6 @@ public class JL5Method extends Method {
 
     public JL5Method(DataInputStream in, ClassFile clazz) {
         super(in, clazz);
-        //        System.err.println("JL5Method created for " + clazz);
     }
 
     @Override
@@ -56,7 +55,6 @@ public class JL5Method extends Method {
 
         name = in.readUnsignedShort();
         type = in.readUnsignedShort();
-        //        System.err.println("JL5Method.initialize() for " + clazz );
 
         int numAttributes = in.readUnsignedShort();
 
@@ -67,7 +65,6 @@ public class JL5Method extends Method {
             int length = in.readInt();
 
             Constant name = clazz.getConstants()[nameIndex];
-            //            System.err.println("    " + name.value());
 
             if (name != null) {
                 if ("Exceptions".equals(name.value())) {

--- a/src/polyglot/ext/jl5/types/reflect/JL5Signature.java
+++ b/src/polyglot/ext/jl5/types/reflect/JL5Signature.java
@@ -340,7 +340,6 @@ public class JL5Signature extends Attribute {
     }
 
     public Result<List<TypeVariable>> formalTypeParamList(String value, int pos) {
-        // System.err.println("### Parsing formal type param list " + value.substring(pos));
         typeVars = null;
         int oldpos = pos;
         createTypeVars = true;
@@ -372,7 +371,6 @@ public class JL5Signature extends Attribute {
 
     // ID classBound interfaceBoundList(opt)
     public Result<TypeVariable> formalTypeParam(String value, int pos) {
-        // System.err.println("### Parsing formalTypeParam " + value.substring(pos));
         String id = "";
         char token = value.charAt(pos);
         while (token != COLON) {
@@ -394,7 +392,6 @@ public class JL5Signature extends Attribute {
             bounds.add(ires.result());
         }
         if (createTypeVars) {
-            // System.err.println("\ncreating type variable " + id + "\n");
             return new Result<>(
                     ts.typeVariable(position, id, ts.intersectionType(position, bounds)), pos);
         } else {
@@ -413,7 +410,6 @@ public class JL5Signature extends Attribute {
     // typeVarSig T...;
     // arrayTypeSig [...;
     public Result<? extends ReferenceType> fieldTypeSig(String value, int pos) {
-        // System.err.println("### Parsing field type sig " + value.substring(pos));
         char token = value.charAt(pos);
         switch (token) {
             case L:
@@ -458,12 +454,9 @@ public class JL5Signature extends Attribute {
                     }
                 case LEFT_ANGLE:
                     { // id is a className
-                        // System.err.println("Parsing type arg list " + value.substring(pos));
                         Result<List<ReferenceType>> tres = typeArgList(value, pos);
-                        // System.err.println("Got " + tres.result());
                         pos = tres.pos();
                         classArgsMap.put(id, tres.result());
-                        // System.err.println("Adding " + tres.result() + " to map for " + id);
                         token = value.charAt(pos);
                         break;
                     }
@@ -479,9 +472,6 @@ public class JL5Signature extends Attribute {
         className += id;
         ClassType ct = null;
         try {
-            // System.err.println("<><> " + className);
-            // ct = (ClassType) ts.typeForName(className);
-            // ct = cls.typeForName()
             ct = (ClassType) ts.systemResolver().find(className);
         } catch (SemanticException e) {
             throw new InternalCompilerError("could not load " + className, e);
@@ -489,13 +479,6 @@ public class JL5Signature extends Attribute {
         // look up in the map the last part of className, i.e., the part after the last '.'.
         // This means that java.util.Map$Entry will go to
         String lookupClassName = className.substring(className.lastIndexOf('.') + 1);
-        // System.err.println("Now looking up " + ct.name() + " with class name '" + className +"'
-        // in classArgsMap " + classArgsMap + "  " + classArgsMap.containsKey(className) + "  " +
-        // createTypeVars);
-        //        if (!className.equals(ct.name())) {
-        //            System.err.println("---- uh oh:   " + className + "   " + ct.name() +"   " +
-        // lookupClassName +"  " +classArgsMap);
-        //        }
         if (classArgsMap.containsKey(lookupClassName)) {
             JL5ParsedClassType pct = parsedClassTypeForClass(ct);
             if (!createTypeVars) {

--- a/src/polyglot/ext/jl5/visit/RemoveEnums.java
+++ b/src/polyglot/ext/jl5/visit/RemoveEnums.java
@@ -425,9 +425,6 @@ public class RemoveEnums extends ContextVisitor {
      * @return
      */
     private Node translateEnumConstantDecl(EnumConstantDecl ecd) {
-        //		System.err.println("Translate enum constant decl " + ecd);
-        //		System.err.println("  " + ecd.constructorInstance());
-        //		System.err.println("  " + ecd.ordinal());
         List<Expr> args = new ArrayList<>();
         // add the name and ordinal
         args.add(nf.StringLit(Position.compilerGenerated(), ecd.name().id()));

--- a/src/polyglot/ext/jl8/parse/jl8.ppg
+++ b/src/polyglot/ext/jl8/parse/jl8.ppg
@@ -49,11 +49,24 @@ parser Grm extends polyglot.ext.jl7.parse.Grm  {:
 	    return nf.CanonicalTypeNode(Position.compilerGenerated(), ts.Int());
 	}
 
+    private static class TypeInCastWithLPAREN {
+        final Token LPARENToken;
+        final Name name;
+        final TypeNode type;
+
+        TypeInCastWithLPAREN(Token LPARENToken, Name name, TypeNode type) {
+            this.LPARENToken = LPARENToken;
+            this.name = name;
+            this.type = type;
+        }
+    }
+
 :};
 
 nonterminal Lambda lambda_expression;
-nonterminal List<Formal> inferred_formal_parameter_list;
+nonterminal List<Formal> inferred_formal_parameter_list, comma_start_formal_parameter_list_opt;
 nonterminal Block lambda_body;
+nonterminal TypeInCastWithLPAREN type_in_cast_with_lparen;
 
 terminal token ARROW;
 terminal token RPAREN_ARROW;
@@ -71,13 +84,95 @@ lambda_expression ::=
         RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(n, b, b), formals, b));
     :}
     | LPAREN:l RPAREN_ARROW lambda_body:b
-    {:
-        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), new ArrayList<Formal>(), b));
-    :}
+    {: RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), new ArrayList<Formal>(), b)); :}
     | LPAREN:l inferred_formal_parameter_list:f RPAREN_ARROW lambda_body:b
+    {: RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b)); :}
+    | LPAREN:l modifiers_or_annotations:m type:t variable_declarator_id:c comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
     {:
+        f.add(0, parser.nf.Formal(parser.pos(t, c, c), m.flags(), m.annotations(), parser.array(t, c.dims), c.name));
         RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
     :}
+    | LPAREN:l modifiers_or_annotations:m type:t ELLIPSIS IDENTIFIER:d comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        ArrayTypeNode typeNode = parser.nf.ArrayTypeNode(parser.pos(t), t);
+        Id id = parser.nf.Id(parser.pos(d), d.getIdentifier());
+        f.add(0, parser.nf.Formal(parser.pos(t, d, d), m.flags(), m.annotations(), typeNode, id, true));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    | LPAREN:l primitive_type:a dims_opt:dims variable_declarator_id:c comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        TypeNode t = parser.array(a, dims.intValue());
+        f.add(0, parser.nf.Formal(parser.pos(a, c, c), Flags.NONE, new ArrayList<AnnotationElem>(), t, c.name));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    | LPAREN:l primitive_type:a dims_opt:dims ELLIPSIS IDENTIFIER:d comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        ArrayTypeNode typeNode = parser.nf.ArrayTypeNode(parser.pos(a), parser.array(a, dims.intValue()));
+        Id id = parser.nf.Id(parser.pos(d), d.getIdentifier());
+        f.add(0, parser.nf.Formal(parser.pos(a, d, d), Flags.NONE, new ArrayList<AnnotationElem>(), typeNode, id, true));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    | LPAREN:l name:n variable_declarator_id:c comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        TypeNode t = parser.array(n.toType(), c.dims);
+        f.add(0, parser.nf.Formal(parser.pos(n, c, c), Flags.NONE, new ArrayList<AnnotationElem>(), t, c.name));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    | LPAREN:l name:n ELLIPSIS IDENTIFIER:d comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        ArrayTypeNode typeNode = parser.nf.ArrayTypeNode(parser.pos(n), n.toType());
+        Id id = parser.nf.Id(parser.pos(d), d.getIdentifier());
+        f.add(0, parser.nf.Formal(parser.pos(n, d, d), Flags.NONE, new ArrayList<AnnotationElem>(), typeNode, id, true));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    | type_in_cast_with_lparen:tl variable_declarator_id:c comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        Token l = tl.LPARENToken;
+        TypeNode t = parser.array(tl.type, c.dims);
+        f.add(0, parser.nf.Formal(parser.pos(l, c, c), Flags.NONE, new ArrayList<AnnotationElem>(), t, c.name));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    | type_in_cast_with_lparen:tl ELLIPSIS IDENTIFIER:d comma_start_formal_parameter_list_opt:f RPAREN_ARROW lambda_body:b
+    {:
+        Token l = tl.LPARENToken;
+        ArrayTypeNode typeNode = parser.nf.ArrayTypeNode(parser.pos(tl.type), tl.type);
+        Id id = parser.nf.Id(parser.pos(d), d.getIdentifier());
+        f.add(0, parser.nf.Formal(parser.pos(l, d, d), Flags.NONE, new ArrayList<AnnotationElem>(), typeNode, id, true));
+        RESULT = parser.nf.Lambda(parser.nf.LambdaFunctionDeclaration(parser.pos(l, b, b), f, b));
+    :}
+    ;
+
+comma_start_formal_parameter_list_opt ::= {: RESULT = new ArrayList<>(); :} | COMMA formal_parameter_list:l {: RESULT = l; :};
+
+type_in_cast_with_lparen ::=
+      LPAREN:p name:a dims:b {: RESULT = new TypeInCastWithLPAREN(p, a, parser.array(a.toType(), b.intValue())); :}
+    | LPAREN:a name:b LT type_argument_list_1:d dims_opt:e
+    {:
+        TypeNode tn = parser.nf.AmbTypeInstantiation(parser.pos(b, d), b.toType(),d);
+        RESULT = new TypeInCastWithLPAREN(a, b, parser.array(tn, e.intValue()));
+    :}
+    | LPAREN:a name:b LT type_argument_list_1:d DOT class_or_interface:f dims_opt:g
+    {:
+        AmbTypeNode bb = (AmbTypeNode)f;
+        TypeNode tn = parser.nf.AmbTypeInstantiation(parser.pos(b, d), parser.exprToType(b.toExpr()),d);
+        RESULT = new TypeInCastWithLPAREN(a, b, parser.array(parser.nf.AmbTypeNode(parser.pos(b, f), tn, bb.id()), g.intValue()));
+    :}
+    | LPAREN:a name:b LT type_argument_list_1:d DOT class_or_interface:f LT type_argument_list_1:h dims_opt:j
+    {:
+        AmbTypeNode bb = (AmbTypeNode)f;
+        TypeNode tn = parser.nf.AmbTypeInstantiation(parser.pos(b, d), parser.exprToType(b.toExpr()), d);
+        tn = parser.nf.AmbTypeInstantiation(parser.pos(b, h), parser.nf.AmbTypeNode(parser.pos(b, f), tn, bb.id()), h);
+        RESULT = new TypeInCastWithLPAREN(a, b, parser.array(tn, j.intValue()));
+    :}
+    ;
+
+override cast_expression ::=
+      LPAREN:p primitive_type:a dims_opt:b RPAREN unary_expression:c
+    {: RESULT = parser.nf.Cast(parser.pos(p, c,a), parser.array(a, b.intValue()), c); :}
+    | LPAREN:a name:b RPAREN unary_expression_not_plus_minus:d
+    {: RESULT = parser.nf.Cast(parser.pos(a, d, b), b.toType(), d); :}
+    | type_in_cast_with_lparen:tl RPAREN unary_expression_not_plus_minus:c
+    {: RESULT = parser.nf.Cast(parser.pos(tl.LPARENToken, c, tl.name), tl.type, c); :}
     ;
 
 inferred_formal_parameter_list ::=

--- a/testsjl8/LambdasWithExplicitTypes.jl8
+++ b/testsjl8/LambdasWithExplicitTypes.jl8
@@ -1,0 +1,41 @@
+import java.lang.annotation.Target;
+import java.util.function.Function;
+import static java.lang.annotation.ElementType.*;
+
+/** Mostly parsing tests for various lambda with explicit type annotations. */
+public class SimpleLambda04 {
+    void test1() {
+        Function<Integer, Integer> negation = (Integer i) -> -i;
+        negation = (final Integer i) -> -i;
+        negation = (@TestAnnotation Integer i) -> -i;
+        negation.apply(3);
+    }
+
+    void test2() {
+        Function<Function<Integer, Integer>, Integer> a = (Function<Integer, Integer> f) -> 0;
+        a = (@TestAnnotation Function<Integer, Integer> f) -> 0;
+    }
+
+    void test3() {
+        Function<Integer[], Integer> a = (Integer[] f) -> 0;
+        a = (Integer... f) -> 0;
+        a = (@TestAnnotation Integer[] f) -> 0;
+        a = (@TestAnnotation Integer... f) -> 0;
+    }
+
+    void test4() {
+        Function<int[], Integer> a = (int[] f) -> 0;
+        a = (int... f) -> 0;
+        a = (@TestAnnotation int[] f) -> 0;
+        a = (@TestAnnotation int... f) -> 0;
+    }
+
+    void test5() {
+        Function<int[][], Integer> a = (int[][] f) -> 0;
+        a = (int[]... f) -> 0;
+        a = (@TestAnnotation int[][] f) -> 0;
+        a = (@TestAnnotation int[]... f) -> 0;
+    }
+}
+
+@Target(value={ANNOTATION_TYPE, TYPE, LOCAL_VARIABLE, PARAMETER}) @interface TestAnnotation {}

--- a/testsjl8/LambdasWithExplicitTypesInvalid.jl8
+++ b/testsjl8/LambdasWithExplicitTypesInvalid.jl8
@@ -1,0 +1,9 @@
+import java.util.function.Function;
+
+public class SimpleLambdaInvalid04 {
+    void test() {
+        // incompatible arg type
+        Function<Integer, Integer> minus = (String i) -> 3;
+        minus.apply(3);
+    }
+}

--- a/testsjl8/SimpleLambda03.jl8
+++ b/testsjl8/SimpleLambda03.jl8
@@ -1,11 +1,12 @@
 import java.util.function.Function;
 
+/** Mostly type checking tests for lambdas in all different positions, except in function call. */
 public class SimpleLambda03 {
     Function<Integer, Integer> a;
     Function<Integer, Integer>[] b;
 
     Function<Integer, Integer> test() {
-        Function<Integer, Integer> negation = null;
+        Function<Integer, Integer> negation = (i) -> -i;
         negation = (i) -> -i;
         negation.apply(3);
         ((Function<Integer, Integer>) (i -> i)).apply(3);

--- a/testsjl8/SimpleLambdaInvalid03.jl8
+++ b/testsjl8/SimpleLambdaInvalid03.jl8
@@ -1,6 +1,6 @@
 import java.util.function.Function;
 
-public class SimpleLambda03 {
+public class SimpleLambdaInvalid03 {
     void test() {
         // Lack of return
         Function<Integer, Integer> minus = (i) -> {};

--- a/testsjl8/pthScript
+++ b/testsjl8/pthScript
@@ -33,6 +33,8 @@
 
 polyglot.ext.jl8.JL8ExtensionInfo "-d out -classpath java-out -assert -noserial -postopts \"-Xlint\\:-options\" -morepermissiveinference" {
 	FunctionInterfaceAnonymousClass.jl8;
+	LambdasWithExplicitTypes.jl8;
+	LambdasWithExplicitTypesInvalid.jl8 (Semantic);
 	SimpleLambda01.jl8;
 	SimpleLambda02.jl8;
 	SimpleLambda03.jl8;

--- a/tools/java_cup/src/java_cup/ErrorManager.java
+++ b/tools/java_cup/src/java_cup/ErrorManager.java
@@ -42,8 +42,6 @@ public class ErrorManager {
     }
 
     public void emit_fatal(String message, Symbol sym) {
-        // System.err.println("Fatal at ("+sym.left+"/"+sym.right+")@"+convSymbol(sym)+" :
-        // "+message);
         System.err.println("Fatal: " + message + " @ " + sym);
         fatals++;
     }
@@ -54,8 +52,6 @@ public class ErrorManager {
     }
 
     public void emit_warning(String message, Symbol sym) {
-        //        System.err.println("Warning at ("+sym.left+"/"+sym.right+")@"+convSymbol(sym)+" :
-        // "+message);
         System.err.println("Fatal: " + message + " @ " + sym);
         warnings++;
     }
@@ -66,8 +62,6 @@ public class ErrorManager {
     }
 
     public void emit_error(String message, Symbol sym) {
-        //        System.err.println("Error at ("+sym.left+"/"+sym.right+")@"+convSymbol(sym)+" :
-        // "+message);
         System.err.println("Error: " + message + " @ " + sym);
         errors++;
     }


### PR DESCRIPTION
General strategy: use the type in cast as a common start to construct the first formal, so that we can avoid shift-reduce conflicts.