### PR TITLE
Type checking lambda expression in call context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: ant
       - name: Build Jar
         run: ant jar
-      - name: Run Base Tests
+      - name: Run Tests
         run: ../bin/pth -ec pthScript
         working-directory: ./tests
 
@@ -47,7 +47,7 @@ jobs:
           java-version: '11'
       - name: Build the base compiler
         run: ant
-      - name: Run Base Tests
+      - name: Run Tests
         run: ../bin/pth -ec pthScript-JL pthScript
         working-directory: ./testsjl5
 
@@ -61,7 +61,7 @@ jobs:
           java-version: '11'
       - name: Build the base compiler
         run: ant
-      - name: Run Base Tests
+      - name: Run Tests
         run: ../bin/pth -ec pthScript-JL pthScript-JL5 pthScript
         working-directory: ./testsjl7
 
@@ -75,6 +75,6 @@ jobs:
           java-version: '11'
       - name: Build the base compiler
         run: ant
-      - name: Run Base Tests
+      - name: Run Tests
         run: ../bin/pth -ec pthScript-JL pthScript-JL5 pthScript-JL7 pthScript
         working-directory: ./testsjl8

--- a/src/polyglot/ext/jl5/ast/JL5CallExt.java
+++ b/src/polyglot/ext/jl5/ast/JL5CallExt.java
@@ -80,7 +80,7 @@ public class JL5CallExt extends JL5ProcedureCallExt implements CallOps {
         return this.expectedReturnType;
     }
 
-    protected void setExpectedReturnType(Type type) {
+    public void setExpectedReturnType(Type type) {
         if (type == null || !type.isCanonical()) {
             expectedReturnType = null;
             return;

--- a/src/polyglot/ext/jl8/ast/JL8CallExt.java
+++ b/src/polyglot/ext/jl8/ast/JL8CallExt.java
@@ -1,7 +1,256 @@
+/*******************************************************************************
+ * This file is part of the Polyglot extensible compiler framework.
+ *
+ * Copyright (c) 2000-2012 Polyglot project group, Cornell University
+ * Copyright (c) 2006-2012 IBM Corporation
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Lesser GNU Public License v2.0 which accompanies this
+ * distribution.
+ *
+ * The development of the Polyglot project has been supported by a
+ * number of funding sources, including DARPA Contract F30602-99-1-0533,
+ * monitored by USAF Rome Laboratory, ONR Grants N00014-01-1-0968 and
+ * N00014-09-1-0652, NSF Grants CNS-0208642, CNS-0430161, CCF-0133302,
+ * and CCF-1054172, AFRL Contract FA8650-10-C-7022, an Alfred P. Sloan
+ * Research Fellowship, and an Intel Research Ph.D. Fellowship.
+ *
+ * See README for contributors.
+ ******************************************************************************/
 package polyglot.ext.jl8.ast;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import polyglot.ast.Assign;
+import polyglot.ast.Call;
+import polyglot.ast.CallOps;
+import polyglot.ast.Expr;
+import polyglot.ast.FieldDecl;
+import polyglot.ast.Lang;
+import polyglot.ast.LocalDecl;
+import polyglot.ast.Node;
+import polyglot.ast.Return;
+import polyglot.ast.Special;
+import polyglot.ast.TypeNode;
+import polyglot.ext.jl5.ast.JL5CallExt;
+import polyglot.ext.jl5.ast.JL5Ext;
+import polyglot.ext.jl5.types.JL5MethodInstance;
+import polyglot.ext.jl5.types.JL5ParsedClassType;
+import polyglot.ext.jl5.types.JL5TypeSystem;
+import polyglot.ext.jl5.types.RawClass;
+import polyglot.ext.jl8.types.JL8TypeSystem;
+import polyglot.types.CodeInstance;
+import polyglot.types.Context;
+import polyglot.types.FunctionInstance;
+import polyglot.types.MethodInstance;
+import polyglot.types.ReferenceType;
+import polyglot.types.SemanticException;
+import polyglot.types.Type;
+import polyglot.types.TypeSystem;
+import polyglot.util.Position;
 import polyglot.util.SerialVersionUID;
+import polyglot.visit.TypeChecker;
 
-public class JL8CallExt extends JL8ProcedureCallExt {
+public class JL8CallExt extends JL8ProcedureCallExt implements CallOps {
     private static final long serialVersionUID = SerialVersionUID.generate();
+
+    public JL8CallExt() {
+        this(null);
+    }
+
+    public JL8CallExt(List<TypeNode> typeArgs) {
+        super(typeArgs);
+    }
+
+    @Override
+    public Call node() {
+        return (Call) super.node();
+    }
+
+    private transient Type expectedReturnType = null;
+
+    @Override
+    public Node typeCheckOverride(Node parent, TypeChecker tc) throws SemanticException {
+        JL8TypeSystem ts = (JL8TypeSystem) tc.typeSystem();
+        Context c = tc.context();
+
+        Call node = (Call) typeArgs(visitList(typeArgs(), tc));
+        node = node.target() == null ? node : node.target(tc.visitEdge(node, node.target()));
+        JL8CallExt ext = (JL8CallExt) JL8Ext.ext(node);
+        JL5CallExt jl5CallExt = (JL5CallExt) JL5Ext.ext(node);
+        List<Expr> partiallyTypeCheckedArguments = new ArrayList<>(node.arguments().size());
+        List<Type> argTypes = new ArrayList<>(node.arguments().size());
+        for (Expr argument : node.arguments()) {
+            Expr checked =
+                    argument instanceof Lambda
+                            ? argument.type(ts.unknownType(Position.COMPILER_GENERATED))
+                            : tc.rethrowMissingDependencies(true).visitEdge(node, argument);
+            partiallyTypeCheckedArguments.add(checked);
+            argTypes.add(checked.type());
+        }
+
+        if (parent instanceof Return) {
+            CodeInstance ci = tc.context().currentCode();
+            if (ci instanceof FunctionInstance) {
+                Type type = ((FunctionInstance) ci).returnType();
+                if (type == null || !type.isCanonical()) return node;
+                ext.expectedReturnType = type;
+                jl5CallExt.setExpectedReturnType(type);
+            }
+        }
+        if (parent instanceof Assign) {
+            Assign a = (Assign) parent;
+            if (this.node() == a.right()) {
+                Type type = a.left().type();
+                if (type == null || !type.isCanonical()) return node;
+                ext.expectedReturnType = type;
+                jl5CallExt.setExpectedReturnType(type);
+            }
+        }
+        if (parent instanceof LocalDecl) {
+            LocalDecl ld = (LocalDecl) parent;
+            Type type = ld.type().type();
+            if (type == null || !type.isCanonical()) return node;
+            ext.expectedReturnType = type;
+            jl5CallExt.setExpectedReturnType(type);
+        }
+        if (parent instanceof FieldDecl) {
+            FieldDecl fd = (FieldDecl) parent;
+            Type type = fd.type().type();
+            if (type == null || !type.isCanonical()) return node;
+            ext.expectedReturnType = type;
+            jl5CallExt.setExpectedReturnType(type);
+        }
+
+        if (node.target() == null) {
+            return lang().typeCheckNullTarget(node, tc, argTypes);
+        }
+        if (node.target().type() == null || !node.target().type().isCanonical()) {
+            return node;
+        }
+        Call call = (Call) node.arguments(partiallyTypeCheckedArguments);
+
+        List<ReferenceType> actualTypeArgs = actualTypeArgs();
+
+        ReferenceType targetType = tc.lang().findTargetType(call);
+
+        /* This call is in a static context if and only if
+         * the target (possibly implicit) is a type node.
+         */
+        boolean staticContext = (call.target() instanceof TypeNode);
+
+        if (staticContext && targetType instanceof RawClass) {
+            targetType = ((RawClass) targetType).base();
+        }
+
+        JL5MethodInstance mi =
+                (JL5MethodInstance)
+                        ts.findMethod(
+                                targetType,
+                                call.name(),
+                                argTypes,
+                                actualTypeArgs,
+                                c.currentClass(),
+                                ext.expectedReturnType,
+                                !(call.target() instanceof Special));
+
+        List<Expr> fullyTypeCheckedArguments =
+                new ArrayList<>(partiallyTypeCheckedArguments.size());
+        for (int i = 0; i < partiallyTypeCheckedArguments.size(); i++) {
+            Expr argument = partiallyTypeCheckedArguments.get(i);
+            if (argument instanceof Lambda) {
+                Lambda lambda = (Lambda) argument;
+                Type lambdaTargetType = mi.formalTypes().get(i);
+                lambda.setTargetType(lambdaTargetType, tc);
+                fullyTypeCheckedArguments.add((Expr) lambda.visit(tc));
+            } else {
+                fullyTypeCheckedArguments.add(argument);
+            }
+        }
+        call = (Call) call.arguments(fullyTypeCheckedArguments);
+
+        if (staticContext && !mi.flags().isStatic()) {
+            throw new SemanticException(
+                    "Cannot call non-static method "
+                            + call.name()
+                            + " of "
+                            + call.target().type()
+                            + " in static "
+                            + "context.",
+                    call.position());
+        }
+
+        // If the target is super, but the method is abstract, then complain.
+        if (call.target() instanceof Special
+                && ((Special) call.target()).kind() == Special.SUPER
+                && mi.flags().isAbstract()) {
+            throw new SemanticException(
+                    "Cannot call an abstract method " + "of the super class", call.position());
+        }
+
+        Type returnType = computeReturnType(mi);
+
+        call = (Call) call.methodInstance(mi).type(returnType);
+
+        // Need to deal with Object.getClass() specially. See JLS 3rd ed., section 4.3.2
+        if (mi.name().equals("getClass") && mi.formalTypes().isEmpty()) {
+            // the return type of the call is "Class<? extends |T|>" where T is the static type of
+            // the receiver.
+            Type t = call.target().type();
+            ReferenceType et = (ReferenceType) ts.erasureType(t);
+            ReferenceType wt = ts.wildCardType(call.position(), et, null);
+            Type instClass =
+                    ts.instantiate(
+                            call.position(),
+                            (JL5ParsedClassType) ts.Class(),
+                            Collections.singletonList(wt));
+            call = (Call) call.type(instClass);
+        }
+
+        return call;
+    }
+
+    private Type computeReturnType(JL5MethodInstance mi) throws SemanticException {
+        JL5TypeSystem ts = (JL5TypeSystem) mi.typeSystem();
+        if (mi.returnType().isVoid()) return ts.Void();
+        return ts.applyCaptureConversion(mi.returnType(), this.node().position());
+    }
+
+    @Override
+    public Type findContainer(TypeSystem ts, MethodInstance mi) {
+        JL5TypeSystem jts = (JL5TypeSystem) ts;
+        return jts.erasureType(mi.container());
+    }
+
+    @Override
+    public ReferenceType findTargetType() throws SemanticException {
+        return superLang().findTargetType(node());
+    }
+
+    @Override
+    public Node typeCheckNullTarget(TypeChecker tc, List<Type> argTypes) throws SemanticException {
+        return superLang().typeCheckNullTarget(node(), tc, argTypes);
+    }
+
+    @Override
+    public boolean constantValueSet(Lang lang) {
+        return superLang().constantValueSet(node(), lang);
+    }
+
+    @Override
+    public boolean isConstant(Lang lang) {
+        return superLang().isConstant(node(), lang);
+    }
+
+    @Override
+    public Object constantValue(Lang lang) {
+        return superLang().constantValue(node(), lang);
+    }
 }

--- a/src/polyglot/ext/jl8/ast/JL8NewExt.java
+++ b/src/polyglot/ext/jl8/ast/JL8NewExt.java
@@ -1,7 +1,42 @@
+/*******************************************************************************
+ * This file is part of the Polyglot extensible compiler framework.
+ *
+ * Copyright (c) 2000-2012 Polyglot project group, Cornell University
+ * Copyright (c) 2006-2012 IBM Corporation
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Lesser GNU Public License v2.0 which accompanies this
+ * distribution.
+ *
+ * The development of the Polyglot project has been supported by a
+ * number of funding sources, including DARPA Contract F30602-99-1-0533,
+ * monitored by USAF Rome Laboratory, ONR Grants N00014-01-1-0968 and
+ * N00014-09-1-0652, NSF Grants CNS-0208642, CNS-0430161, CCF-0133302,
+ * and CCF-1054172, AFRL Contract FA8650-10-C-7022, an Alfred P. Sloan
+ * Research Fellowship, and an Intel Research Ph.D. Fellowship.
+ *
+ * See README for contributors.
+ ******************************************************************************/
 package polyglot.ext.jl8.ast;
 
+import java.util.List;
+import polyglot.ast.TypeNode;
 import polyglot.util.SerialVersionUID;
 
 public class JL8NewExt extends JL8ProcedureCallExt {
     private static final long serialVersionUID = SerialVersionUID.generate();
+
+    public JL8NewExt() {
+        this(null);
+    }
+
+    public JL8NewExt(List<TypeNode> typeArgs) {
+        super(typeArgs);
+    }
 }

--- a/src/polyglot/ext/jl8/ast/Lambda.java
+++ b/src/polyglot/ext/jl8/ast/Lambda.java
@@ -26,9 +26,14 @@
 package polyglot.ext.jl8.ast;
 
 import polyglot.ast.Expr;
+import polyglot.types.SemanticException;
+import polyglot.types.Type;
+import polyglot.visit.TypeChecker;
 
 public interface Lambda extends Expr {
     LambdaFunctionDeclaration declaration();
 
     Lambda declaration(LambdaFunctionDeclaration declaration);
+
+    void setTargetType(Type type, TypeChecker tc) throws SemanticException;
 }

--- a/src/polyglot/ext/jl8/ast/LambdaFunctionDeclaration.java
+++ b/src/polyglot/ext/jl8/ast/LambdaFunctionDeclaration.java
@@ -52,6 +52,7 @@ import polyglot.util.Position;
 import polyglot.visit.CFGBuilder;
 import polyglot.visit.NodeVisitor;
 import polyglot.visit.PrettyPrinter;
+import polyglot.visit.TypeChecker;
 
 public class LambdaFunctionDeclaration extends Term_c implements CodeNode, Returnable {
 
@@ -162,6 +163,12 @@ public class LambdaFunctionDeclaration extends Term_c implements CodeNode, Retur
             }
         }
         throw new SemanticException(targetType + " is not a functional interface.", position());
+    }
+
+    @Override
+    public Node typeCheckOverride(Node parent, TypeChecker tc) throws SemanticException {
+        if (this.targetType != null) return super.typeCheckOverride(parent, tc);
+        return this; // Not ready for type checking!
     }
 
     protected <N extends LambdaFunctionDeclaration> N formals(N n, List<Formal> formals) {

--- a/src/polyglot/ext/jl8/ast/Lambda_c.java
+++ b/src/polyglot/ext/jl8/ast/Lambda_c.java
@@ -138,7 +138,8 @@ public class Lambda_c extends Expr_c implements Lambda {
         return super.typeCheckOverride(parent, tc);
     }
 
-    private void setTargetType(Type type, TypeChecker tc) throws SemanticException {
+    @Override
+    public void setTargetType(Type type, TypeChecker tc) throws SemanticException {
         this.declaration.setTargetType(
                 type, (JL8TypeSystem) tc.context().typeSystem(), tc.nodeFactory());
     }

--- a/src/polyglot/ext/jl8/types/JL8TypeSystem_c.java
+++ b/src/polyglot/ext/jl8/types/JL8TypeSystem_c.java
@@ -31,8 +31,16 @@ import polyglot.ext.jl7.types.JL7TypeSystem_c;
 import polyglot.types.Flags;
 import polyglot.types.MethodInstance;
 import polyglot.types.ReferenceType;
+import polyglot.types.Type;
+import polyglot.types.UnknownType;
 
 public class JL8TypeSystem_c extends JL7TypeSystem_c implements JL8TypeSystem {
+    @Override
+    public boolean isImplicitCastValid(Type fromType, Type toType) {
+        if (fromType instanceof UnknownType) return true;
+        return super.isImplicitCastValid(fromType, toType);
+    }
+
     @Override
     public List<MethodInstance> nonObjectPublicAbstractMethods(ReferenceType referenceType) {
         List<MethodInstance> objectPublicMethods = this.objectPublicMethods();

--- a/testsjl5/Generics36.jl5
+++ b/testsjl5/Generics36.jl5
@@ -1,21 +1,16 @@
 class C {
     <T> T m(T o) { return null; }
     <S> S m() { return null; }
-    Integer foo() { 
-	Boolean b = m(Boolean.TRUE);
-	return m(null); 
+
+    Integer foo() {
+	    Boolean b = m(Boolean.TRUE);
+	    return m(null);
     }
 
     Boolean boo = m();
-    
-    Integer bar() { 
-	Boolean b = m();
-	return m(); 
-    }
 
-    /*
-      void n(Integer x) { }
-      void quux() {
-      //	n(m(null));
-      }*/
+    Integer bar() {
+	    Boolean b = m();
+	    return m();
+    }
 }

--- a/testsjl8/SimpleLambda04.jl8
+++ b/testsjl8/SimpleLambda04.jl8
@@ -1,0 +1,12 @@
+import java.util.function.Function;
+
+/** Mostly type checking tests for lambdas in all different positions, except in function call. */
+public class SimpleLambda04 {
+    void expectLambda(Function<Integer, Integer> f) {}
+
+    Function<Integer, Integer> test() {
+        this.expectLambda((i) -> -i);
+        expectLambda((i) -> -i);
+        return i -> 1;
+    }
+}

--- a/testsjl8/SimpleLambdaInvalid04.jl8
+++ b/testsjl8/SimpleLambdaInvalid04.jl8
@@ -1,0 +1,10 @@
+import java.util.function.Function;
+
+public class SimpleLambdaInvalid04 {
+    void expectLambda(Function<Integer, Integer> f) {}
+
+    void test() {
+        this.expectLambda((String i) -> i);
+        expectLambda((String i) -> i);
+    }
+}

--- a/testsjl8/pthScript
+++ b/testsjl8/pthScript
@@ -38,7 +38,9 @@ polyglot.ext.jl8.JL8ExtensionInfo "-d out -classpath java-out -assert -noserial 
 	SimpleLambda01.jl8;
 	SimpleLambda02.jl8;
 	SimpleLambda03.jl8;
+	SimpleLambda04.jl8;
 	SimpleLambdaInvalid01.jl8 (Semantic);
 	SimpleLambdaInvalid02.jl8 (Semantic);
 	SimpleLambdaInvalid03.jl8 (Semantic);
+	SimpleLambdaInvalid04.jl8 (Semantic), (Semantic);
 }

--- a/testsjl8/pthScript-JL
+++ b/testsjl8/pthScript-JL
@@ -321,7 +321,7 @@ polyglot.ext.jl8.JL8ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
 	BadReferences.jl (Semantic, "Member.*ambiguous");
 	BadReferences2.jl (Semantic, "Field.*ambiguous");
 	BadStaticContext.jl (Semantic);
-        BadSwitch1.jl (Semantic, "Case label must be an integral constant");
+    BadSwitch1.jl (Semantic, "Case label must be an integral constant");
 	BadSwitch2.jl (Semantic, "Duplicate case label");
 	Constants12.jl (Semantic, "Duplicate case label"),
                        (Semantic, "Duplicate case label"),
@@ -332,7 +332,7 @@ polyglot.ext.jl8.JL8ExtensionInfo ["../tests/"] "-sx jl -d out -classpath java-o
         CircularInheritance1.jl (Semantic, "Circular inheritance");
         CircularInheritance2.jl (Semantic, "Circular inheritance");
         CircularInheritance3.jl (Semantic, "Circular inheritance");
-	Errors.jl (Semantic, "Method.*cannot be called with arguments");
+	Errors.jl (Semantic, "Method.*cannot be called with arguments"), (Semantic);
 	Errors2.jl (Semantic, "Class .* not found");
 	LabeledBreak2.jl (Semantic, "Unreachable statement");
         InitCheckerBug.jl ;


### PR DESCRIPTION
To implement the bidirectional type checking needed for lambda in call expressions, we need to override the structure of type checking. The override allows us to flexibly consider only some of, but not necessarily all of, arguments' type to resolve to a method.