### PR TITLE
Restore accidentally deleted build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,7 @@
+version.major=2
+version.minor=8
+version.patch=0
+bin.includes=META-INF/,META-INF/MANIFEST.MF,lib/java_cup.jar,lib/jflex.jar
+jars.compile.order=.
+source..=src/
+output..=classes/


### PR DESCRIPTION
The file is accidentally deleted in https://github.com/polyglot-compiler/polyglot/pull/55 and it's now causing `ant dist` to fail. This PR adds it back and updated the version to be 2.8.0.